### PR TITLE
[FD][AOSS-1263] Send XML Content-Type header

### DIFF
--- a/app/uk/gov/hmrc/agentaccesscontrol/connectors/GovernmentGatewayProxyConnector.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/connectors/GovernmentGatewayProxyConnector.scala
@@ -21,6 +21,8 @@ import javax.xml.XMLConstants
 import javax.xml.parsers.SAXParserFactory
 
 import org.apache.xerces.impl.Constants
+import play.api.http.ContentTypes.XML
+import play.api.http.HeaderNames.CONTENT_TYPE
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import uk.gov.hmrc.domain.{AgentCode, SaUtr}
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpPost}
@@ -42,7 +44,7 @@ class GovernmentGatewayProxyConnector(baseUrl: URL, httpPost: HttpPost) {
   val url: URL = new URL(baseUrl, "/government-gateway-proxy/api/admin/GsoAdminGetAssignedAgents")
 
   def getAssignedSaAgents(utr: SaUtr)(implicit hc: HeaderCarrier): Future[Seq[AssignedAgent]] = {
-    httpPost.POSTString(url.toString, body(utr))
+    httpPost.POSTString(url.toString, body(utr), Seq(CONTENT_TYPE -> XML))
       .map(r => parseResponse(r.body))
   }
 

--- a/it/uk/gov/hmrc/agentaccesscontrol/support/BaseISpec.scala
+++ b/it/uk/gov/hmrc/agentaccesscontrol/support/BaseISpec.scala
@@ -121,8 +121,7 @@ trait StubUtils {
     val path: String = "/government-gateway-proxy/api/admin/GsoAdminGetAssignedAgents"
 
     def andIsAssignedToClient(utr: SaUtr): A = {
-      stubFor(post(urlEqualTo(path))
-        .withRequestBody(matching(s".*>$utr<.*"))
+      stubFor(getAssignedAgentsPost(utr)
         .willReturn(aResponse()
           .withBody(
             s"""
@@ -164,8 +163,7 @@ trait StubUtils {
     }
 
     def andIsAllocatedButNotAssignedToClient(utr: SaUtr): A = {
-      stubFor(post(urlEqualTo(path))
-        .withRequestBody(matching(s".*>$utr<.*"))
+      stubFor(getAssignedAgentsPost(utr)
         .willReturn(aResponse()
           .withBody(
             s"""
@@ -207,8 +205,7 @@ trait StubUtils {
     }
 
     def andIsNotAllocatedToClient(utr: SaUtr): A = {
-      stubFor(post(urlEqualTo(path))
-        .withRequestBody(matching(s".*>$utr<.*"))
+      stubFor(getAssignedAgentsPost(utr)
         .willReturn(aResponse()
           .withBody(
             s"""
@@ -218,10 +215,18 @@ trait StubUtils {
           """.stripMargin)))
       this
     }
+
+    private def getAssignedAgentsPost(utr: SaUtr) = {
+      post(urlEqualTo(path))
+        .withRequestBody(matching(s".*>$utr<.*"))
+        .withHeader("Content-Type", equalTo("application/xml; charset=utf-8"))
+    }
+
     def andGovernmentGatewayProxyReturnsAnError500(): A = {
       stubFor(post(urlEqualTo(path)).willReturn(aResponse().withStatus(500)))
       this
     }
+
     def andGovernmentGatewayReturnsUnparseableXml(utr: String): A = {
       stubFor(post(urlEqualTo(path))
         .withRequestBody(matching(s".*>$utr<.*"))


### PR DESCRIPTION
This header is required by the government-gateway-proxy service - SAAuthSpec in agent-end-to-end-tests fails without it.