### PR TITLE
[FD][AOSS-1639] Add affinityGroup and agentUserRole to decision auditing

### DIFF
--- a/app/uk/gov/hmrc/agentaccesscontrol/audit/AuditService.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/audit/AuditService.scala
@@ -66,7 +66,7 @@ trait AuditService {
 }
 
 object AgentAccessControlEvent extends Enumeration {
-  val GGW_Decision,CESA_Decision,AAC_Decision,GGW_Response,CESA_Response = Value
+  val GGW_Decision,CESA_Decision,AgentAccessControlDecision,GGW_Response,CESA_Response = Value
 
   type AgentAccessControlEvent = AgentAccessControlEvent.Value
 }

--- a/app/uk/gov/hmrc/agentaccesscontrol/service/AuthorisationService.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/service/AuthorisationService.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.agentaccesscontrol.service
 
 import uk.gov.hmrc.agentaccesscontrol.audit.{AgentAccessControlEvent, AuditService}
-import uk.gov.hmrc.agentaccesscontrol.connectors.AuthConnector
+import uk.gov.hmrc.agentaccesscontrol.connectors.{AuthConnector, AuthDetails}
 import uk.gov.hmrc.domain.{AgentCode, SaUtr}
 import uk.gov.hmrc.play.http.HeaderCarrier
 
@@ -30,28 +30,41 @@ class AuthorisationService(cesaAuthorisationService: CesaAuthorisationService,
   extends LoggingAuthorisationResults {
 
   def isAuthorised(agentCode: AgentCode, saUtr: SaUtr)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Boolean] =
-    authConnector.currentAgentIdentifiers().flatMap {
-      case Some((Some(saAgentReference), ggCredentialId)) =>
+    authConnector.currentAuthDetails().flatMap {
+      case Some(agentAuthDetails@AuthDetails(Some(saAgentReference), ggCredentialId, _, _)) =>
         val results = cesaAuthorisationService.isAuthorisedInCesa(agentCode, saAgentReference, saUtr) zip
           ggAuthorisationService.isAuthorisedInGovernmentGateway(agentCode, ggCredentialId, saUtr)
         results.map { case (cesa, ggw) => {
           val result = cesa && ggw
-          logResult(cesa, ggw, agentCode, ggCredentialId, saUtr, result)
+          logResult(agentCode, agentAuthDetails, saUtr, cesa, ggw, result)
           result
         } }
-      case Some((None, _)) =>
+      case Some(AuthDetails(None, _, _, _)) =>
         Future successful notAuthorised(s"No 6 digit agent reference found for agent $agentCode")
       case None =>
         Future successful notAuthorised("No user is logged in")
     }
 
-  def logResult(cesa: Boolean, ggw: Boolean, agentCode: AgentCode, ggCredentialId: String, saUtr: SaUtr, result: Boolean)
-               (implicit hc: HeaderCarrier) = {
-    auditService.auditEvent(AgentAccessControlEvent.AAC_Decision, agentCode, saUtr,
-                            Seq("ggCredentialId" -> ggCredentialId, "result" -> result, "cesa" -> cesa, "ggw" -> ggw))
+  private def logResult(
+    agentCode: AgentCode, agentAuthDetails: AuthDetails, saUtr: SaUtr,
+    cesa: Boolean, ggw: Boolean, result: Boolean)
+    (implicit hc: HeaderCarrier) = {
+
+    val optionalDetails = Seq(
+      agentAuthDetails.affinityGroup.map("affinityGroup" -> _),
+      agentAuthDetails.agentUserRole.map("agentUserRole" -> _)).flatten
+
+    auditService.auditEvent(
+      AgentAccessControlEvent.AAC_Decision, agentCode, saUtr,
+      Seq("ggCredentialId" -> agentAuthDetails.ggCredentialId,
+        "result" -> result, "cesa" -> cesa, "ggw" -> ggw)
+      ++ optionalDetails)
+
     (cesa, ggw) match {
-      case (true, true) => authorised(s"Access allowed for agentCode=$agentCode ggCredential=$ggCredentialId client=$saUtr")
-      case (_, _) => notAuthorised(s"Access not allowed for agentCode=$agentCode ggCredential=$ggCredentialId client=$saUtr cesa=$cesa ggw=$ggw")
+      case (true, true) =>
+        authorised(s"Access allowed for agentCode=$agentCode ggCredential=${agentAuthDetails.ggCredentialId} client=$saUtr")
+      case (_, _) =>
+        notAuthorised(s"Access not allowed for agentCode=$agentCode ggCredential=${agentAuthDetails.ggCredentialId} client=$saUtr cesa=$cesa ggw=$ggw")
     }
   }
 

--- a/app/uk/gov/hmrc/agentaccesscontrol/service/AuthorisationService.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/service/AuthorisationService.scala
@@ -55,7 +55,7 @@ class AuthorisationService(cesaAuthorisationService: CesaAuthorisationService,
       agentAuthDetails.agentUserRole.map("agentUserRole" -> _)).flatten
 
     auditService.auditEvent(
-      AgentAccessControlEvent.AAC_Decision, agentCode, saUtr,
+      AgentAccessControlEvent.AgentAccessControlDecision, agentCode, saUtr,
       Seq("ggCredentialId" -> agentAuthDetails.ggCredentialId,
         "result" -> result, "cesa" -> cesa, "ggw" -> ggw)
       ++ optionalDetails)

--- a/it/uk/gov/hmrc/agentaccesscontrol/support/BaseISpec.scala
+++ b/it/uk/gov/hmrc/agentaccesscontrol/support/BaseISpec.scala
@@ -314,7 +314,18 @@ trait StubUtils {
       this
     }
 
-    def isLoggedIn(): A = {
+    private val defaultOnlyUsedByAuditingAuthorityJson =
+      s"""
+         |  ,
+         |  "accounts": {
+         |    "agent": {
+         |      "agentUserRole": "admin"
+         |    }
+         |  },
+         |  "affinityGroup": "Agent"
+       """.stripMargin
+
+    def isLoggedIn(onlyUsedByAuditingAuthorityJson: String = defaultOnlyUsedByAuditingAuthorityJson): A = {
       stubFor(get(urlPathEqualTo(s"/auth/authority")).willReturn(aResponse().withStatus(200).withBody(
         s"""
            |{
@@ -322,6 +333,7 @@ trait StubUtils {
            |  "credentials":{
            |    "gatewayId":"$agentCredId"
            |  }
+           |  $onlyUsedByAuditingAuthorityJson
            |}
        """.stripMargin
       )))

--- a/test/uk/gov/hmrc/agentaccesscontrol/service/AuthorisationServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentaccesscontrol/service/AuthorisationServiceSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.agentaccesscontrol.service
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import uk.gov.hmrc.agentaccesscontrol.audit.AgentAccessControlEvent.AAC_Decision
+import uk.gov.hmrc.agentaccesscontrol.audit.AgentAccessControlEvent.AgentAccessControlDecision
 import uk.gov.hmrc.agentaccesscontrol.audit.AuditService
 import uk.gov.hmrc.agentaccesscontrol.connectors.{AuthConnector, AuthDetails}
 import uk.gov.hmrc.domain.{AgentCode, SaAgentReference, SaUtr}
@@ -52,7 +52,7 @@ class AuthorisationServiceSpec extends UnitSpec with MockitoSugar {
         .thenReturn(false)
 
       await(authorisationService.isAuthorised(agentCode, clientSaUtr)) shouldBe false
-      verify(mockAuditService).auditEvent(AAC_Decision, agentCode, clientSaUtr,
+      verify(mockAuditService).auditEvent(AgentAccessControlDecision, agentCode, clientSaUtr,
         Seq("ggCredentialId" -> "ggId", "result" -> false, "cesa" -> false, "ggw" -> true, "affinityGroup" -> "Agent", "agentUserRole" -> "admin"))
     }
 
@@ -63,7 +63,7 @@ class AuthorisationServiceSpec extends UnitSpec with MockitoSugar {
         .thenReturn(true)
 
       await(authorisationService.isAuthorised(agentCode, clientSaUtr)) shouldBe true
-      verify(mockAuditService).auditEvent(AAC_Decision, agentCode, clientSaUtr,
+      verify(mockAuditService).auditEvent(AgentAccessControlDecision, agentCode, clientSaUtr,
         Seq("ggCredentialId" -> "ggId", "result" -> true, "cesa" -> true, "ggw" -> true, "affinityGroup" -> "Agent", "agentUserRole" -> "admin"))
     }
 
@@ -74,7 +74,7 @@ class AuthorisationServiceSpec extends UnitSpec with MockitoSugar {
         .thenReturn(true)
 
       await(authorisationService.isAuthorised(agentCode, clientSaUtr)) shouldBe true
-      verify(mockAuditService).auditEvent(AAC_Decision, agentCode, clientSaUtr,
+      verify(mockAuditService).auditEvent(AgentAccessControlDecision, agentCode, clientSaUtr,
         Seq("ggCredentialId" -> "ggId", "result" -> true, "cesa" -> true, "ggw" -> true, "affinityGroup" -> "Organisation", "agentUserRole" -> "assistant"))
     }
 
@@ -85,7 +85,7 @@ class AuthorisationServiceSpec extends UnitSpec with MockitoSugar {
         .thenReturn(true)
 
       await(authorisationService.isAuthorised(agentCode, clientSaUtr)) shouldBe true
-      verify(mockAuditService).auditEvent(AAC_Decision, agentCode, clientSaUtr,
+      verify(mockAuditService).auditEvent(AgentAccessControlDecision, agentCode, clientSaUtr,
         Seq("ggCredentialId" -> "ggId", "result" -> true, "cesa" -> true, "ggw" -> true))
     }
 
@@ -96,7 +96,7 @@ class AuthorisationServiceSpec extends UnitSpec with MockitoSugar {
         .thenReturn(true)
 
       await(authorisationService.isAuthorised(agentCode, clientSaUtr)) shouldBe false
-      verify(mockAuditService).auditEvent(AAC_Decision, agentCode, clientSaUtr,
+      verify(mockAuditService).auditEvent(AgentAccessControlDecision, agentCode, clientSaUtr,
         Seq("ggCredentialId" -> "ggId", "result" -> false, "cesa" -> true, "ggw" -> false, "affinityGroup" -> "Agent", "agentUserRole" -> "admin"))
     }
 
@@ -107,7 +107,7 @@ class AuthorisationServiceSpec extends UnitSpec with MockitoSugar {
         .thenReturn(false)
 
       await(authorisationService.isAuthorised(agentCode, clientSaUtr)) shouldBe false
-      verify(mockAuditService).auditEvent(AAC_Decision, agentCode, clientSaUtr,
+      verify(mockAuditService).auditEvent(AgentAccessControlDecision, agentCode, clientSaUtr,
         Seq("ggCredentialId" -> "ggId", "result" -> false, "cesa" -> false, "ggw" -> false, "affinityGroup" -> "Agent", "agentUserRole" -> "admin"))
     }
 


### PR DESCRIPTION
I'm planning to do more work in this area (add 6 digit agent ref to decision auditing, remove redundant audit events, use implicit instead of explicit for some events) but thought it would be easier to review as a series of small PRs instead of one big one.