### PR TITLE
[MS] APB-43 added whitelist filter

### DIFF
--- a/app/uk/gov/hmrc/agentaccesscontrol/controllers/WhitelistController.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/controllers/WhitelistController.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentaccesscontrol.controllers
+
+import play.api.mvc.Action
+import uk.gov.hmrc.play.microservice.controller.BaseController
+
+class WhitelistController extends BaseController {
+
+  val unauthorised = Action {
+    Unauthorized
+  }
+
+}

--- a/app/uk/gov/hmrc/agentaccesscontrol/controllers/WhitelistController.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/controllers/WhitelistController.scala
@@ -21,8 +21,8 @@ import uk.gov.hmrc.play.microservice.controller.BaseController
 
 class WhitelistController extends BaseController {
 
-  val unauthorised = Action {
-    Unauthorized
+  val forbidden = Action {
+    Forbidden
   }
 
 }

--- a/app/uk/gov/hmrc/agentaccesscontrol/microserviceGlobal.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/microserviceGlobal.scala
@@ -16,8 +16,11 @@
 
 package uk.gov.hmrc.agentaccesscontrol
 
+import java.util.Base64
+
 import com.typesafe.config.Config
-import play.api.{Application, Configuration, Play}
+import play.api.mvc.Call
+import play.api.{Logger, Application, Configuration, Play}
 import uk.gov.hmrc.play.audit.filters.AuditFilter
 import uk.gov.hmrc.play.auth.controllers.AuthParamsControllerConfig
 import uk.gov.hmrc.play.config.{AppName, ControllerConfig, RunMode}
@@ -26,6 +29,7 @@ import uk.gov.hmrc.play.microservice.bootstrap.DefaultMicroserviceGlobal
 import uk.gov.hmrc.play.auth.microservice.filters.AuthorisationFilter
 import net.ceedubs.ficus.Ficus._
 import uk.gov.hmrc.agent.kenshoo.monitoring.MonitoringFilter
+import uk.gov.hmrc.whitelist.AkamaiWhitelistFilter
 
 object ControllerConfiguration extends ControllerConfig {
   lazy val controllerConfigs = Play.current.configuration.underlying.as[Config]("controllers")
@@ -54,7 +58,39 @@ object MicroserviceAuthFilter extends AuthorisationFilter {
   override def controllerNeedsAuth(controllerName: String): Boolean = ControllerConfiguration.paramsForController(controllerName).needsAuth
 }
 
+class WhitelistFilter extends AkamaiWhitelistFilter {
+  import play.api.Play.current
+
+  override val whitelist: Seq[String] = whitelistConfig("microservice.whitelist.ips")
+  override val destination: Call = Call("GET", "/agent-access-control/unauthorised")
+  override val excludedPaths: Seq[Call] = Seq(
+    Call("GET", "/ping/ping"),
+    Call("GET", "/admin/details"),
+    Call("GET", "/admin/metrics"),
+    Call("GET", "/agent-access-control/unauthorised")
+  )
+
+  private def whitelistConfig(key: String): Seq[String] =
+    new String(Base64.getDecoder().decode(Play.configuration.getString(key).getOrElse("")), "UTF-8").split(",")
+}
+
+object WhitelistFilter {
+  import play.api.Play.current
+
+  def enabled(): Boolean = Play.configuration.getBoolean("microservice.whitelist.enabled").getOrElse(true)
+
+}
+
 trait MicroserviceGlobal extends DefaultMicroserviceGlobal with RunMode with ServiceRegistry with ControllerRegistry {
+  private lazy val whitelistFilterSeq = WhitelistFilter.enabled match {
+    case true =>
+      Logger.info("Starting microservice with IP whitelist enabled")
+      Seq(new WhitelistFilter)
+    case _ =>
+      Logger.info("Starting microservice with IP whitelist disabled")
+      Seq.empty
+  }
+
   override val auditConnector = MicroserviceAuditConnector
 
   override def microserviceMetricsConfig(implicit app: Application): Option[Configuration] = app.configuration.getConfig(s"microservice.metrics")
@@ -65,7 +101,7 @@ trait MicroserviceGlobal extends DefaultMicroserviceGlobal with RunMode with Ser
 
   override val authFilter = Some(MicroserviceAuthFilter)
 
-  override def microserviceFilters = defaultMicroserviceFilters ++ Seq(MicroserviceMonitoringFilter)
+  override def microserviceFilters = whitelistFilterSeq ++ defaultMicroserviceFilters ++ Seq(MicroserviceMonitoringFilter)
 
   override def getControllerInstance[A](controllerClass: Class[A]): A = {
     getController(controllerClass)

--- a/app/uk/gov/hmrc/agentaccesscontrol/microserviceGlobal.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/microserviceGlobal.scala
@@ -62,12 +62,12 @@ class WhitelistFilter extends AkamaiWhitelistFilter {
   import play.api.Play.current
 
   override val whitelist: Seq[String] = whitelistConfig("microservice.whitelist.ips")
-  override val destination: Call = Call("GET", "/agent-access-control/unauthorised")
+  override val destination: Call = Call("GET", "/agent-access-control/forbidden")
   override val excludedPaths: Seq[Call] = Seq(
     Call("GET", "/ping/ping"),
     Call("GET", "/admin/details"),
     Call("GET", "/admin/metrics"),
-    Call("GET", "/agent-access-control/unauthorised")
+    Call("GET", "/agent-access-control/forbidden")
   )
 
   private def whitelistConfig(key: String): Seq[String] =

--- a/app/uk/gov/hmrc/agentaccesscontrol/microserviceWiring.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/microserviceWiring.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.agent.kenshoo.monitoring.MonitoredWSHttp
 import uk.gov.hmrc.agentaccesscontrol.audit.AuditService
 import uk.gov.hmrc.agentaccesscontrol.connectors.{GovernmentGatewayProxyConnector, AuthConnector => OurAuthConnector}
 import uk.gov.hmrc.agentaccesscontrol.connectors.desapi.DesAgentClientApiConnector
-import uk.gov.hmrc.agentaccesscontrol.controllers.AuthorisationController
+import uk.gov.hmrc.agentaccesscontrol.controllers.{WhitelistController, AuthorisationController}
 import uk.gov.hmrc.agentaccesscontrol.service.{AuthorisationService, CesaAuthorisationService, GovernmentGatewayAuthorisationService}
 import uk.gov.hmrc.play.audit.http.config.LoadAuditingConfig
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
@@ -68,7 +68,8 @@ trait ControllerRegistry {
   registry: ServiceRegistry =>
 
   private lazy val controllers = Map[Class[_], Controller](
-    classOf[AuthorisationController] -> new AuthorisationController(auditService, authorisationService)
+    classOf[AuthorisationController] -> new AuthorisationController(auditService, authorisationService),
+    classOf[WhitelistController] -> new WhitelistController()
   )
 
   def getController[A](controllerClass: Class[A]) : A = controllers(controllerClass).asInstanceOf[A]

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -5,4 +5,4 @@
 GET    /sa-auth/agent/:agentCode/client/:saUtr    @uk.gov.hmrc.agentaccesscontrol.controllers.AuthorisationController.isAuthorised(agentCode: uk.gov.hmrc.domain.AgentCode, saUtr: uk.gov.hmrc.domain.SaUtr)
 
 # For whitelisting
-GET    /unauthorised                              @uk.gov.hmrc.agentaccesscontrol.controllers.WhitelistController.unauthorised
+GET    /forbidden                                 @uk.gov.hmrc.agentaccesscontrol.controllers.WhitelistController.forbidden

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -3,3 +3,6 @@
 
 
 GET    /sa-auth/agent/:agentCode/client/:saUtr    @uk.gov.hmrc.agentaccesscontrol.controllers.AuthorisationController.isAuthorised(agentCode: uk.gov.hmrc.domain.AgentCode, saUtr: uk.gov.hmrc.domain.SaUtr)
+
+# For whitelisting
+GET    /unauthorised                              @uk.gov.hmrc.agentaccesscontrol.controllers.WhitelistController.unauthorised

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -85,6 +85,12 @@ controllers {
             pattern = "/[^/]+/([^/]+)/([^/]+)?.*"
         }
     }
+
+    uk.gov.hmrc.agentaccesscontrol.controllers.WhitelistController = {
+        needsAuth = false
+        needsLogging = false
+        needsAuditing = false
+    }
 }
 
 
@@ -144,6 +150,11 @@ microservice {
             prefix = play.${appName}.
             enabled = false
         }
+    }
+
+    whitelist {
+        ips = ""
+        enabled = false
     }
 }
 

--- a/it/uk/gov/hmrc/agentaccesscontrol/WhitelistISpec.scala
+++ b/it/uk/gov/hmrc/agentaccesscontrol/WhitelistISpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentaccesscontrol
+
+import java.util.Base64
+
+import uk.gov.hmrc.agentaccesscontrol.support.{BaseISpec, Resource}
+import uk.gov.hmrc.domain.{AgentCode, SaAgentReference, SaUtr}
+import uk.gov.hmrc.play.http.HttpResponse
+
+class WhitelistISpec extends BaseISpec {
+
+  val agentCode = AgentCode("ABCDEF123456")
+  val saAgentReference = SaAgentReference("ABC456")
+  val clientUtr = SaUtr("123")
+
+  override protected def additionalConfiguration: Map[String, String] = Map(
+    "microservice.whitelist.enabled" -> "true",
+    "microservice.whitelist.ips" -> Base64.getEncoder().encodeToString("192.168.1.2,192.168.1.3".getBytes))
+
+
+  "SA delegated auth rule" should {
+    "respond with NOT_IMPLEMENTED if whitelist is enabled and there is no IP address in header" in {
+      givenLoggedInAgentIsAuthorised()
+
+      authResponseFor(agentCode, clientUtr, None).status shouldBe 501
+    }
+
+    "respond with UNAUTHORISED if whitelist is enabled and there is an IP address in header that is not on the list" in {
+      givenLoggedInAgentIsAuthorised()
+
+      authResponseFor(agentCode, clientUtr, Some("192.168.1.1")).status shouldBe 401
+    }
+
+    "be enabled if whitelist is enabled and there is an IP address in header that is on the list" in {
+      givenLoggedInAgentIsAuthorised()
+
+      authResponseFor(agentCode, clientUtr, Some("192.168.1.2")).status shouldBe 200
+      authResponseFor(agentCode, clientUtr, Some("192.168.1.3")).status shouldBe 200
+    }
+  }
+
+  "ping" should {
+    "be available regardless of IP address in the header" in {
+      new Resource("/ping/ping")(port).get().status shouldBe 200
+    }
+  }
+
+  "admin details" should {
+    "be available regardless of IP address in the header" in {
+      new Resource("/admin/details")(port).get().status shouldBe 200
+    }
+  }
+
+  "metrics" should {
+    "be available regardless of IP address in the header" in {
+      new Resource("/admin/metrics")(port).get().status shouldBe 200
+    }
+  }
+
+
+  def givenLoggedInAgentIsAuthorised(): Unit = {
+    given()
+      .agentAdmin(agentCode).isLoggedIn()
+      .andHasSaAgentReferenceWithEnrolment(saAgentReference)
+      .andIsAllocatedAndAssignedToClient(clientUtr)
+      .andIsRelatedToClientInDes(clientUtr).andAuthorisedByBoth648AndI648()
+  }
+
+  def authResponseFor(agentCode: AgentCode, clientSaUtr: SaUtr, trueClientIp: Option[String]): HttpResponse =
+    new Resource(s"/agent-access-control/sa-auth/agent/${agentCode.value}/client/${clientSaUtr.value}")(port).get(trueClientIp)
+
+}

--- a/it/uk/gov/hmrc/agentaccesscontrol/WhitelistISpec.scala
+++ b/it/uk/gov/hmrc/agentaccesscontrol/WhitelistISpec.scala
@@ -40,10 +40,10 @@ class WhitelistISpec extends BaseISpec {
       authResponseFor(agentCode, clientUtr, None).status shouldBe 501
     }
 
-    "respond with UNAUTHORISED if whitelist is enabled and there is an IP address in header that is not on the list" in {
+    "respond with FORBIDDEN if whitelist is enabled and there is an IP address in header that is not on the list" in {
       givenLoggedInAgentIsAuthorised()
 
-      authResponseFor(agentCode, clientUtr, Some("192.168.1.1")).status shouldBe 401
+      authResponseFor(agentCode, clientUtr, Some("192.168.1.1")).status shouldBe 403
     }
 
     "be enabled if whitelist is enabled and there is an IP address in header that is on the list" in {

--- a/it/uk/gov/hmrc/agentaccesscontrol/support/BaseISpec.scala
+++ b/it/uk/gov/hmrc/agentaccesscontrol/support/BaseISpec.scala
@@ -38,6 +38,8 @@ abstract class BaseISpec extends UnitSpec
 
   implicit val hc = HeaderCarrier()
 
+  protected def additionalConfiguration: Map[String, String] = Map.empty
+
   override implicit lazy val app: FakeApplication = FakeApplication(
     additionalConfiguration = Map(
       configDesHost -> wiremockHost,
@@ -46,7 +48,7 @@ abstract class BaseISpec extends UnitSpec
       configAuthPort -> wiremockPort,
       ggProxyHost -> wiremockHost,
       ggProxyPort -> wiremockPort
-    )
+    ) ++ additionalConfiguration
   )
 
 }

--- a/it/uk/gov/hmrc/agentaccesscontrol/support/Http.scala
+++ b/it/uk/gov/hmrc/agentaccesscontrol/support/Http.scala
@@ -58,7 +58,7 @@ class Resource(path: String)(port: Int) {
 
   def url = s"http://localhost:$port$path"
 
-  def get() =
-    Http.get(url)(HeaderCarrier())
+  def get(trueClientIp: Option[String] = None) =
+    Http.get(url)(HeaderCarrier(trueClientIp = trueClientIp))
 
 }

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -35,6 +35,7 @@ private object AppDependencies {
     "uk.gov.hmrc" %% "play-url-binders" % playUrlBindersVersion,
     "uk.gov.hmrc" %% "play-config" % playConfigVersion,
     "uk.gov.hmrc" %% "play-json-logger" % playJsonLoggerVersion,
+    "uk.gov.hmrc" %% "play-whitelist-filter" % "1.1.0",
     "uk.gov.hmrc" %% "domain" % domainVersion,
     "uk.gov.hmrc" %% "agent-kenshoo-monitoring" % "1.9.0"
   )

--- a/test/uk/gov/hmrc/agentaccesscontrol/controllers/WhitelistControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentaccesscontrol/controllers/WhitelistControllerSpec.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentaccesscontrol.controllers
+
+import play.api.test.FakeRequest
+import uk.gov.hmrc.play.test.UnitSpec
+
+class WhitelistControllerSpec extends UnitSpec {
+
+  "WhitelistController.blocked" should {
+    "respond with 401" in {
+      val ctrl = new WhitelistController()
+      status(ctrl.unauthorised(FakeRequest())) shouldBe 401
+    }
+  }
+}

--- a/test/uk/gov/hmrc/agentaccesscontrol/controllers/WhitelistControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentaccesscontrol/controllers/WhitelistControllerSpec.scala
@@ -21,10 +21,10 @@ import uk.gov.hmrc.play.test.UnitSpec
 
 class WhitelistControllerSpec extends UnitSpec {
 
-  "WhitelistController.blocked" should {
-    "respond with 401" in {
+  "WhitelistController.forbidden" should {
+    "respond with 403" in {
       val ctrl = new WhitelistController()
-      status(ctrl.unauthorised(FakeRequest())) shouldBe 401
+      status(ctrl.forbidden(FakeRequest())) shouldBe 403
     }
   }
 }


### PR DESCRIPTION
Whitelist filter is disabled by default as there might not be akamai's `True-Client-IP` header in dev, QA or staging.