### PR TITLE
[FD][AOSS-1639] Add 6 char SA agent ref to decision audit events

### DIFF
--- a/app/uk/gov/hmrc/agentaccesscontrol/service/AuthorisationService.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/service/AuthorisationService.scala
@@ -51,6 +51,7 @@ class AuthorisationService(cesaAuthorisationService: CesaAuthorisationService,
     (implicit hc: HeaderCarrier) = {
 
     val optionalDetails = Seq(
+      agentAuthDetails.saAgentReference.map("saAgentReference" -> _),
       agentAuthDetails.affinityGroup.map("affinityGroup" -> _),
       agentAuthDetails.agentUserRole.map("agentUserRole" -> _)).flatten
 

--- a/test/uk/gov/hmrc/agentaccesscontrol/service/AuthorisationServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentaccesscontrol/service/AuthorisationServiceSpec.scala
@@ -53,7 +53,7 @@ class AuthorisationServiceSpec extends UnitSpec with MockitoSugar {
 
       await(authorisationService.isAuthorised(agentCode, clientSaUtr)) shouldBe false
       verify(mockAuditService).auditEvent(AgentAccessControlDecision, agentCode, clientSaUtr,
-        Seq("ggCredentialId" -> "ggId", "result" -> false, "cesa" -> false, "ggw" -> true, "affinityGroup" -> "Agent", "agentUserRole" -> "admin"))
+        Seq("ggCredentialId" -> "ggId", "result" -> false, "cesa" -> false, "ggw" -> true, "saAgentReference" -> saAgentRef, "affinityGroup" -> "Agent", "agentUserRole" -> "admin"))
     }
 
     "return true if SA agent reference is found and CesaAuthorisationService returns true and GG Authorisation returns true" in new Context {
@@ -64,18 +64,20 @@ class AuthorisationServiceSpec extends UnitSpec with MockitoSugar {
 
       await(authorisationService.isAuthorised(agentCode, clientSaUtr)) shouldBe true
       verify(mockAuditService).auditEvent(AgentAccessControlDecision, agentCode, clientSaUtr,
-        Seq("ggCredentialId" -> "ggId", "result" -> true, "cesa" -> true, "ggw" -> true, "affinityGroup" -> "Agent", "agentUserRole" -> "admin"))
+        Seq("ggCredentialId" -> "ggId", "result" -> true, "cesa" -> true, "ggw" -> true, "saAgentReference" -> saAgentRef, "affinityGroup" -> "Agent", "agentUserRole" -> "admin"))
     }
 
-    "audit different values for affinityGroup and agentUserRole" in new Context {
-      when(mockAuthConnector.currentAuthDetails()).thenReturn(Some(AuthDetails(Some(saAgentRef), "ggId", affinityGroup = Some("Organisation"), agentUserRole = Some("assistant"))))
+    "not hard code audited values" in new Context {
+      val differentSaAgentRef = SaAgentReference("XYZ123")
+
+      when(mockAuthConnector.currentAuthDetails()).thenReturn(Some(AuthDetails(Some(differentSaAgentRef), "ggId", affinityGroup = Some("Organisation"), agentUserRole = Some("assistant"))))
       when(mockGGAuthorisationService.isAuthorisedInGovernmentGateway(agentCode, "ggId", clientSaUtr)).thenReturn(true)
-      when(mockCesaAuthorisationService.isAuthorisedInCesa(agentCode, saAgentRef, clientSaUtr))
+      when(mockCesaAuthorisationService.isAuthorisedInCesa(agentCode, differentSaAgentRef, clientSaUtr))
         .thenReturn(true)
 
       await(authorisationService.isAuthorised(agentCode, clientSaUtr)) shouldBe true
       verify(mockAuditService).auditEvent(AgentAccessControlDecision, agentCode, clientSaUtr,
-        Seq("ggCredentialId" -> "ggId", "result" -> true, "cesa" -> true, "ggw" -> true, "affinityGroup" -> "Organisation", "agentUserRole" -> "assistant"))
+        Seq("ggCredentialId" -> "ggId", "result" -> true, "cesa" -> true, "ggw" -> true, "saAgentReference" -> differentSaAgentRef, "affinityGroup" -> "Organisation", "agentUserRole" -> "assistant"))
     }
 
     "still work if the fields only used for auditing are removed from the auth record" in new Context {
@@ -86,7 +88,7 @@ class AuthorisationServiceSpec extends UnitSpec with MockitoSugar {
 
       await(authorisationService.isAuthorised(agentCode, clientSaUtr)) shouldBe true
       verify(mockAuditService).auditEvent(AgentAccessControlDecision, agentCode, clientSaUtr,
-        Seq("ggCredentialId" -> "ggId", "result" -> true, "cesa" -> true, "ggw" -> true))
+        Seq("ggCredentialId" -> "ggId", "result" -> true, "cesa" -> true, "ggw" -> true, "saAgentReference" -> saAgentRef))
     }
 
     "return false if SA agent reference is found and CesaAuthorisationService returns true and GG Authorisation returns false" in new Context {
@@ -97,7 +99,7 @@ class AuthorisationServiceSpec extends UnitSpec with MockitoSugar {
 
       await(authorisationService.isAuthorised(agentCode, clientSaUtr)) shouldBe false
       verify(mockAuditService).auditEvent(AgentAccessControlDecision, agentCode, clientSaUtr,
-        Seq("ggCredentialId" -> "ggId", "result" -> false, "cesa" -> true, "ggw" -> false, "affinityGroup" -> "Agent", "agentUserRole" -> "admin"))
+        Seq("ggCredentialId" -> "ggId", "result" -> false, "cesa" -> true, "ggw" -> false, "saAgentReference" -> saAgentRef, "affinityGroup" -> "Agent", "agentUserRole" -> "admin"))
     }
 
     "return false if SA agent reference is found and CesaAuthorisationService returns false and GG Authorisation returns false" in new Context {
@@ -108,7 +110,7 @@ class AuthorisationServiceSpec extends UnitSpec with MockitoSugar {
 
       await(authorisationService.isAuthorised(agentCode, clientSaUtr)) shouldBe false
       verify(mockAuditService).auditEvent(AgentAccessControlDecision, agentCode, clientSaUtr,
-        Seq("ggCredentialId" -> "ggId", "result" -> false, "cesa" -> false, "ggw" -> false, "affinityGroup" -> "Agent", "agentUserRole" -> "admin"))
+        Seq("ggCredentialId" -> "ggId", "result" -> false, "cesa" -> false, "ggw" -> false, "saAgentReference" -> saAgentRef, "affinityGroup" -> "Agent", "agentUserRole" -> "admin"))
     }
 
     "return false if user is not logged in" in new Context {

--- a/test/uk/gov/hmrc/agentaccesscontrol/service/AuthorisationServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentaccesscontrol/service/AuthorisationServiceSpec.scala
@@ -43,6 +43,8 @@ class AuthorisationServiceSpec extends UnitSpec with MockitoSugar {
       when(mockAuthConnector.currentAuthDetails()).thenReturn(Some(AuthDetails(None, "ggId", affinityGroup = Some("Agent"), agentUserRole = Some("admin"))))
 
       await(authorisationService.isAuthorised(agentCode, clientSaUtr)) shouldBe false
+      verify(mockAuditService).auditEvent(AgentAccessControlDecision, agentCode, clientSaUtr,
+        Seq("ggCredentialId" -> "ggId", "result" -> false, "affinityGroup" -> "Agent", "agentUserRole" -> "admin"))
     }
 
     "return false if SA agent reference is found and CesaAuthorisationService returns false and GG Authorisation returns true" in new Context {


### PR DESCRIPTION
Also audit the decision in a case where we previously didn't send an audit event (when we deny access because we couldn't find the agent reference)