### PR TITLE
AOSS-1639 remove redundant auditing

### DIFF
--- a/app/uk/gov/hmrc/agentaccesscontrol/audit/AuditService.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/audit/AuditService.scala
@@ -59,7 +59,7 @@ class AuditService(val auditConnector: AuditConnector) {
 }
 
 object AgentAccessControlEvent extends Enumeration {
-  val GGW_Decision,CESA_Decision,AgentAccessControlDecision,GGW_Response = Value
+  val GGW_Decision,CESA_Decision,AgentAccessControlDecision = Value
 
   type AgentAccessControlEvent = AgentAccessControlEvent.Value
 }

--- a/app/uk/gov/hmrc/agentaccesscontrol/audit/AuditService.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/audit/AuditService.scala
@@ -59,7 +59,7 @@ class AuditService(val auditConnector: AuditConnector) {
 }
 
 object AgentAccessControlEvent extends Enumeration {
-  val CESA_Decision,AgentAccessControlDecision = Value
+  val AgentAccessControlDecision = Value
 
   type AgentAccessControlEvent = AgentAccessControlEvent.Value
 }

--- a/app/uk/gov/hmrc/agentaccesscontrol/audit/AuditService.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/audit/AuditService.scala
@@ -59,7 +59,7 @@ class AuditService(val auditConnector: AuditConnector) {
 }
 
 object AgentAccessControlEvent extends Enumeration {
-  val GGW_Decision,CESA_Decision,AgentAccessControlDecision = Value
+  val CESA_Decision,AgentAccessControlDecision = Value
 
   type AgentAccessControlEvent = AgentAccessControlEvent.Value
 }

--- a/app/uk/gov/hmrc/agentaccesscontrol/audit/AuditService.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/audit/AuditService.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.agentaccesscontrol.audit
 
-import uk.gov.hmrc.agentaccesscontrol.MicroserviceAuditConnector
 import uk.gov.hmrc.domain.{AgentCode, SaUtr}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.model.DataEvent
@@ -26,15 +25,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.Try
 
-object AuditService extends AuditService {
-  override protected val auditConnector = MicroserviceAuditConnector
-}
-
-trait AuditService {
+class AuditService(val auditConnector: AuditConnector) {
 
   import AgentAccessControlEvent.AgentAccessControlEvent
-
-  protected def auditConnector: AuditConnector
 
   def auditEvent(event: AgentAccessControlEvent,
                  agentCode: AgentCode,

--- a/app/uk/gov/hmrc/agentaccesscontrol/audit/AuditService.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/audit/AuditService.scala
@@ -59,7 +59,7 @@ class AuditService(val auditConnector: AuditConnector) {
 }
 
 object AgentAccessControlEvent extends Enumeration {
-  val GGW_Decision,CESA_Decision,AgentAccessControlDecision,GGW_Response,CESA_Response = Value
+  val GGW_Decision,CESA_Decision,AgentAccessControlDecision,GGW_Response = Value
 
   type AgentAccessControlEvent = AgentAccessControlEvent.Value
 }

--- a/app/uk/gov/hmrc/agentaccesscontrol/microserviceGlobal.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/microserviceGlobal.scala
@@ -40,7 +40,7 @@ object AuthParamsControllerConfiguration extends AuthParamsControllerConfig {
 }
 
 object MicroserviceAuditFilter extends AuditFilter with AppName {
-  override val auditConnector = MicroserviceAuditConnector
+  override val auditConnector = MicroserviceGlobal.auditConnector
   override def controllerNeedsAuditing(controllerName: String) = ControllerConfiguration.paramsForController(controllerName).needsAuditing
 }
 
@@ -90,8 +90,6 @@ trait MicroserviceGlobal extends DefaultMicroserviceGlobal with RunMode with Ser
       Logger.info("Starting microservice with IP whitelist disabled")
       Seq.empty
   }
-
-  override val auditConnector = MicroserviceAuditConnector
 
   override def microserviceMetricsConfig(implicit app: Application): Option[Configuration] = app.configuration.getConfig(s"microservice.metrics")
 

--- a/app/uk/gov/hmrc/agentaccesscontrol/microserviceWiring.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/microserviceWiring.scala
@@ -62,7 +62,7 @@ trait ServiceRegistry extends ServicesConfig {
     new DesAgentClientApiConnector(baseUrl("des"), desAuthToken, desEnvironment, WSHttp)
   }
   lazy val authConnector = new OurAuthConnector(new URL(baseUrl("auth")), WSHttp)
-  lazy val cesaAuthorisationService = new CesaAuthorisationService(desAgentClientApiConnector, auditService)
+  lazy val cesaAuthorisationService = new CesaAuthorisationService(desAgentClientApiConnector)
   lazy val ggProxyConnector: GovernmentGatewayProxyConnector =
     new GovernmentGatewayProxyConnector(new URL(baseUrl("government-gateway-proxy")), WSHttp)
   lazy val ggAuthorisationService = new GovernmentGatewayAuthorisationService(ggProxyConnector)

--- a/app/uk/gov/hmrc/agentaccesscontrol/microserviceWiring.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/microserviceWiring.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.agent.kenshoo.monitoring.MonitoredWSHttp
 import uk.gov.hmrc.agentaccesscontrol.audit.AuditService
 import uk.gov.hmrc.agentaccesscontrol.connectors.{GovernmentGatewayProxyConnector, AuthConnector => OurAuthConnector}
 import uk.gov.hmrc.agentaccesscontrol.connectors.desapi.DesAgentClientApiConnector
-import uk.gov.hmrc.agentaccesscontrol.controllers.{WhitelistController, AuthorisationController}
+import uk.gov.hmrc.agentaccesscontrol.controllers.{AuthorisationController, WhitelistController}
 import uk.gov.hmrc.agentaccesscontrol.service.{AuthorisationService, CesaAuthorisationService, GovernmentGatewayAuthorisationService}
 import uk.gov.hmrc.play.audit.http.config.LoadAuditingConfig
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
@@ -39,7 +39,7 @@ object WSHttp extends WSGet with WSPut with WSPost with WSDelete with WSPatch wi
   override val hooks: Seq[HttpHook] = NoneRequired
 }
 
-object MicroserviceAuditConnector extends AuditConnector with RunMode {
+class MicroserviceAuditConnector extends AuditConnector with RunMode {
   override lazy val auditingConfig = LoadAuditingConfig(s"auditing")
 }
 
@@ -49,7 +49,8 @@ object MicroserviceAuthConnector extends AuthConnector with ServicesConfig {
 
 
 trait ServiceRegistry extends ServicesConfig {
-  lazy val auditService: AuditService.type = AuditService
+  lazy val auditConnector: AuditConnector = new MicroserviceAuditConnector
+  lazy val auditService = new AuditService(auditConnector)
   lazy val desAgentClientApiConnector = {
     val desAuthToken = getConfString("des.authorization-token", throw new RuntimeException("Could not find DES authorisation token"))
     val desEnvironment = getConfString("des.environment", throw new RuntimeException("Could not find DES environment"))

--- a/app/uk/gov/hmrc/agentaccesscontrol/microserviceWiring.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/microserviceWiring.scala
@@ -65,7 +65,7 @@ trait ServiceRegistry extends ServicesConfig {
   lazy val cesaAuthorisationService = new CesaAuthorisationService(desAgentClientApiConnector, auditService)
   lazy val ggProxyConnector: GovernmentGatewayProxyConnector =
     new GovernmentGatewayProxyConnector(new URL(baseUrl("government-gateway-proxy")), WSHttp)
-  lazy val ggAuthorisationService = new GovernmentGatewayAuthorisationService(ggProxyConnector, auditService)
+  lazy val ggAuthorisationService = new GovernmentGatewayAuthorisationService(ggProxyConnector)
   lazy val authorisationService: AuthorisationService =
     new AuthorisationService(cesaAuthorisationService, authConnector, ggAuthorisationService, auditService)
 }

--- a/app/uk/gov/hmrc/agentaccesscontrol/microserviceWiring.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/microserviceWiring.scala
@@ -64,7 +64,7 @@ trait ServiceRegistry extends ServicesConfig {
   lazy val authConnector = new OurAuthConnector(new URL(baseUrl("auth")), WSHttp)
   lazy val cesaAuthorisationService = new CesaAuthorisationService(desAgentClientApiConnector, auditService)
   lazy val ggProxyConnector: GovernmentGatewayProxyConnector =
-    new GovernmentGatewayProxyConnector(new URL(baseUrl("government-gateway-proxy")), WSHttp, auditService)
+    new GovernmentGatewayProxyConnector(new URL(baseUrl("government-gateway-proxy")), WSHttp)
   lazy val ggAuthorisationService = new GovernmentGatewayAuthorisationService(ggProxyConnector, auditService)
   lazy val authorisationService: AuthorisationService =
     new AuthorisationService(cesaAuthorisationService, authConnector, ggAuthorisationService, auditService)

--- a/app/uk/gov/hmrc/agentaccesscontrol/service/CesaAuthorisationService.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/service/CesaAuthorisationService.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.agentaccesscontrol.service
 
-import uk.gov.hmrc.agentaccesscontrol.audit.AgentAccessControlEvent.CESA_Decision
-import uk.gov.hmrc.agentaccesscontrol.audit.AuditService
 import uk.gov.hmrc.agentaccesscontrol.connectors.desapi.DesAgentClientApiConnector
 import uk.gov.hmrc.agentaccesscontrol.model.{DesAgentClientFlagsApiResponse, FoundResponse, NotFoundResponse}
 import uk.gov.hmrc.domain.{AgentCode, SaAgentReference, SaUtr}
@@ -25,8 +23,7 @@ import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class CesaAuthorisationService(desAgentClientApiConnector: DesAgentClientApiConnector,
-                               auditService: AuditService)
+class CesaAuthorisationService(desAgentClientApiConnector: DesAgentClientApiConnector)
   extends LoggingAuthorisationResults {
 
   def isAuthorisedInCesa(agentCode: AgentCode, saAgentReference: SaAgentReference, saUtr: SaUtr)
@@ -40,15 +37,12 @@ class CesaAuthorisationService(desAgentClientApiConnector: DesAgentClientApiConn
                                (implicit headerCarrier: HeaderCarrier): Boolean = {
     response match {
       case NotFoundResponse => {
-        auditService.auditEvent(CESA_Decision, agentCode, saUtr, Seq("result" -> false, "response" -> "not-found"))
         notAuthorised(s"DES API returned not found for agent $agentCode and client $saUtr")
       }
       case FoundResponse(true, true) => {
-        auditService.auditEvent(CESA_Decision, agentCode, saUtr, Seq("result" -> true))
         authorised(s"DES API returned true for both flags for agent $agentCode and client $saUtr")
       }
       case FoundResponse(auth64_8, authI64_8) => {
-        auditService.auditEvent(CESA_Decision, agentCode, saUtr, Seq("result" -> false, "64-8" -> auth64_8, "i64-8" -> authI64_8))
         notAuthorised(s"DES API returned false for at least one flag agent $agentCode and client $saUtr. 64-8=$auth64_8, i64-8=$authI64_8")
       }
     }

--- a/app/uk/gov/hmrc/agentaccesscontrol/service/GovernmentGatewayAuthorisationService.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/service/GovernmentGatewayAuthorisationService.scala
@@ -17,30 +17,17 @@
 package uk.gov.hmrc.agentaccesscontrol.service
 
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import uk.gov.hmrc.agentaccesscontrol.audit.AgentAccessControlEvent.GGW_Decision
-import uk.gov.hmrc.agentaccesscontrol.audit.AuditService
 import uk.gov.hmrc.agentaccesscontrol.connectors.GovernmentGatewayProxyConnector
 import uk.gov.hmrc.domain.{AgentCode, SaUtr}
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
 
-class GovernmentGatewayAuthorisationService(val ggProxyConnector: GovernmentGatewayProxyConnector,
-                                            val auditService: AuditService) extends LoggingAuthorisationResults {
+class GovernmentGatewayAuthorisationService(val ggProxyConnector: GovernmentGatewayProxyConnector) extends LoggingAuthorisationResults {
 
   def isAuthorisedInGovernmentGateway(agentCode: AgentCode, ggCredentialId: String, saUtr: SaUtr)(implicit hc: HeaderCarrier): Future[Boolean] = {
     ggProxyConnector.getAssignedSaAgents(saUtr, agentCode) map { assignedAgents =>
-      val result = assignedAgents.exists(_.matches(agentCode, ggCredentialId))
-      logResult(agentCode, ggCredentialId, saUtr, result)
-      result
-    }
-  }
-
-  def logResult(agentCode: AgentCode, ggCredentialId: String, saUtr: SaUtr, result: Boolean)(implicit hc: HeaderCarrier) = {
-    auditService.auditEvent(GGW_Decision, agentCode, saUtr, Seq("ggCredentialId" -> ggCredentialId, "result" -> result))
-    result match {
-      case true => authorised(s"GGW relationship found for agentCode=$agentCode ggCredential=$ggCredentialId client=$saUtr")
-      case false => notAuthorised(s"GGW relationship not found for agentCode=$agentCode ggCredential=$ggCredentialId client=$saUtr")
+      assignedAgents.exists(_.matches(agentCode, ggCredentialId))
     }
   }
 }

--- a/it/uk/gov/hmrc/agentaccesscontrol/connectors/GovernmentGatewayProxyConnectorSpec.scala
+++ b/it/uk/gov/hmrc/agentaccesscontrol/connectors/GovernmentGatewayProxyConnectorSpec.scala
@@ -3,24 +3,18 @@ package uk.gov.hmrc.agentaccesscontrol.connectors
 import java.net.URL
 
 import com.kenshoo.play.metrics.MetricsRegistry
-import org.mockito.Matchers
-import org.mockito.Matchers.any
-import org.mockito.Mockito.verify
 import org.scalatest.mock.MockitoSugar
 import uk.gov.hmrc.agentaccesscontrol.WSHttp
-import uk.gov.hmrc.agentaccesscontrol.audit.AgentAccessControlEvent.GGW_Response
-import uk.gov.hmrc.agentaccesscontrol.audit.AuditService
 import uk.gov.hmrc.agentaccesscontrol.support.BaseISpec
 import uk.gov.hmrc.domain.{AgentCode, SaUtr}
-import uk.gov.hmrc.play.http.{HeaderCarrier, Upstream5xxResponse}
+import uk.gov.hmrc.play.http.Upstream5xxResponse
 
 import scala.xml.SAXParseException
 
 class GovernmentGatewayProxyConnectorSpec extends BaseISpec with MockitoSugar {
 
-  val auditService = mock[AuditService]
   val agentCode = AgentCode("AgentCode")
-  val connector = new GovernmentGatewayProxyConnector(new URL(wiremockBaseUrl), WSHttp, auditService)
+  val connector = new GovernmentGatewayProxyConnector(new URL(wiremockBaseUrl), WSHttp)
 
   "GovernmentGatewayProxy" should {
     "return agent allocations and assignments" in {
@@ -44,10 +38,6 @@ class GovernmentGatewayProxyConnectorSpec extends BaseISpec with MockitoSugar {
 
       val credentials2 = details1.assignedCredentials.head
       credentials2.identifier shouldBe "98741987654322"
-      verify(auditService).auditEvent(Matchers.eq(GGW_Response),
-                                      Matchers.eq(agentCode),
-                                      Matchers.eq(SaUtr("1234567890")),
-                                      any[Seq[(String,Any)]])(any[HeaderCarrier])
     }
 
     "return empty list if there are no allocated agencies nor assigned credentials" in {
@@ -75,6 +65,7 @@ class GovernmentGatewayProxyConnectorSpec extends BaseISpec with MockitoSugar {
 
       an[Upstream5xxResponse] should be thrownBy await(connector.getAssignedSaAgents(new SaUtr("1234567890"), agentCode))
     }
+
     "record metrics for outbound call" in {
       val metricsRegistry = MetricsRegistry.defaultRegistry
       given()

--- a/it/uk/gov/hmrc/agentaccesscontrol/connectors/desapi/DesAgentClientApiConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentaccesscontrol/connectors/desapi/DesAgentClientApiConnectorISpec.scala
@@ -17,17 +17,21 @@
 package uk.gov.hmrc.agentaccesscontrol.connectors.desapi
 
 import com.kenshoo.play.metrics.MetricsRegistry
-import org.mockito.Matchers
-import org.mockito.Matchers.any
-import org.mockito.Mockito.verify
+import org.mockito.ArgumentCaptor
+import org.mockito.Matchers.{any, eq => eqs}
+import org.mockito.Mockito.{verify, when}
+import org.scalatest.concurrent.Eventually
 import org.scalatest.mock.MockitoSugar
+import play.api.libs.json.Json
 import uk.gov.hmrc.agentaccesscontrol.WSHttp
-import uk.gov.hmrc.agentaccesscontrol.audit.AgentAccessControlEvent.CESA_Response
-import uk.gov.hmrc.agentaccesscontrol.audit.AuditService
 import uk.gov.hmrc.agentaccesscontrol.model.{DesAgentClientFlagsApiResponse, FoundResponse, NotFoundResponse}
 import uk.gov.hmrc.agentaccesscontrol.support.BaseISpec
 import uk.gov.hmrc.domain.{AgentCode, SaAgentReference, SaUtr}
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
+import uk.gov.hmrc.play.audit.model.MergedDataEvent
 import uk.gov.hmrc.play.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext
 
 
 class DesAgentClientApiConnectorISpec extends BaseISpec with MockitoSugar {
@@ -40,7 +44,7 @@ class DesAgentClientApiConnectorISpec extends BaseISpec with MockitoSugar {
       givenClientIsLoggedIn()
         .andIsRelatedToClientInDes(saUtr, "auth_token_33", "env_33").andAuthorisedByBoth648AndI648()
 
-      val connectorWithDifferentHeaders = new DesAgentClientApiConnector(wiremockBaseUrl, "auth_token_33", "env_33", WSHttp, auditService)
+      val connectorWithDifferentHeaders = new DesAgentClientApiConnector(wiremockBaseUrl, "auth_token_33", "env_33", wsHttp)
 
       val response: DesAgentClientFlagsApiResponse = await(connectorWithDifferentHeaders.getAgentClientRelationship(saAgentReference, agentCode, saUtr))
       response shouldBe FoundResponse(auth64_8 = true, authI64_8 = true)
@@ -51,41 +55,31 @@ class DesAgentClientApiConnectorISpec extends BaseISpec with MockitoSugar {
         givenClientIsLoggedIn()
           .andIsRelatedToClientInDes(saUtr).andAuthorisedByBoth648AndI648()
 
+        when(mockAuditConnector.sendMergedEvent(any[MergedDataEvent])(eqs(headerCarrier), any[ExecutionContext])).thenThrow(new RuntimeException("EXCEPTION!"))
+
         await(connector.getAgentClientRelationship(saAgentReference, agentCode, saUtr)) shouldBe FoundResponse(auth64_8 = true, authI64_8 = true)
-        verify(auditService).auditEvent(Matchers.eq(CESA_Response),
-                                        Matchers.eq(agentCode),
-                                        Matchers.eq(saUtr),
-                                        any[Seq[(String,Any)]])(any[HeaderCarrier])
+        outboundCallToDesShouldBeAudited(auth64_8 = true, authI64_8 = true)
       }
       "agent is authorised by only i64-8" in new Context {
         givenClientIsLoggedIn()
           .andIsRelatedToClientInDes(saUtr).andIsAuthorisedByOnlyI648()
 
         await(connector.getAgentClientRelationship(saAgentReference, agentCode, saUtr)) shouldBe FoundResponse(auth64_8 = false, authI64_8 = true)
-        verify(auditService).auditEvent(Matchers.eq(CESA_Response),
-                                        Matchers.eq(agentCode),
-                                        Matchers.eq(saUtr),
-                                        any[Seq[(String,Any)]])(any[HeaderCarrier])
+        outboundCallToDesShouldBeAudited(auth64_8 = false, authI64_8 = true)
       }
       "agent is authorised by only 64-8" in new Context {
         givenClientIsLoggedIn()
           .andIsRelatedToClientInDes(saUtr).andIsAuthorisedByOnly648()
 
         await(connector.getAgentClientRelationship(saAgentReference, agentCode, saUtr)) shouldBe FoundResponse(auth64_8 = true, authI64_8 = false)
-        verify(auditService).auditEvent(Matchers.eq(CESA_Response),
-                                        Matchers.eq(agentCode),
-                                        Matchers.eq(saUtr),
-                                        any[Seq[(String,Any)]])(any[HeaderCarrier])
+        outboundCallToDesShouldBeAudited(auth64_8 = true, authI64_8 = false)
       }
       "agent is not authorised" in new Context {
         givenClientIsLoggedIn()
           .andIsRelatedToClientInDes(saUtr).butIsNotAuthorised()
 
         await(connector.getAgentClientRelationship(saAgentReference, agentCode, saUtr)) shouldBe FoundResponse(auth64_8 = false, authI64_8 = false)
-        verify(auditService).auditEvent(Matchers.eq(CESA_Response),
-                                        Matchers.eq(agentCode),
-                                        Matchers.eq(saUtr),
-                                        any[Seq[(String,Any)]])(any[HeaderCarrier])
+        outboundCallToDesShouldBeAudited(auth64_8 = false, authI64_8 = false)
       }
     }
 
@@ -101,6 +95,7 @@ class DesAgentClientApiConnectorISpec extends BaseISpec with MockitoSugar {
 
       an[Exception] should be thrownBy await(connector.getAgentClientRelationship(saAgentReference, agentCode, saUtr))
     }
+
     "Metrics are logged for the outbound call" in new Context {
       val metricsRegistry = MetricsRegistry.defaultRegistry
       givenClientIsLoggedIn()
@@ -111,9 +106,13 @@ class DesAgentClientApiConnectorISpec extends BaseISpec with MockitoSugar {
     }
   }
 
-  private abstract class Context {
-    val auditService = mock[AuditService]
-    val connector = new DesAgentClientApiConnector(wiremockBaseUrl, "secret", "test", WSHttp, auditService)
+  private abstract class Context extends Eventually {
+    val mockAuditConnector = mock[AuditConnector]
+    val wsHttp = new WSHttp {
+      override def auditConnector = mockAuditConnector
+    }
+
+    val connector = new DesAgentClientApiConnector(wiremockBaseUrl, "secret", "test", wsHttp)
     val saAgentReference = SaAgentReference("AGENTR")
     val saUtr = SaUtr("SAUTR456")
 
@@ -121,5 +120,23 @@ class DesAgentClientApiConnectorISpec extends BaseISpec with MockitoSugar {
       given()
         .agentAdmin("ABCDEF122345").isLoggedIn()
         .andHasSaAgentReferenceWithEnrolment(saAgentReference)
+
+    def outboundCallToDesShouldBeAudited(auth64_8: Boolean, authI64_8: Boolean): Unit = {
+      // HttpAuditing.AuditingHook does the auditing asynchronously, so we need
+      // to use eventually to avoid a race condition in this test
+      eventually {
+        val captor = ArgumentCaptor.forClass(classOf[MergedDataEvent])
+        verify(mockAuditConnector).sendMergedEvent(captor.capture())(any[HeaderCarrier], any[ExecutionContext])
+        val event: MergedDataEvent = captor.getValue
+
+        event.auditType shouldBe "OutboundCall"
+
+        event.request.tags("path") shouldBe s"$wiremockBaseUrl/sa/agents/$saAgentReference/client/$saUtr"
+
+        val responseJson = Json.parse(event.response.detail("responseMessage"))
+        (responseJson \ "Auth_64-8").as[Boolean] shouldBe auth64_8
+        (responseJson \ "Auth_i64-8").as[Boolean] shouldBe authI64_8
+      }
+    }
   }
 }

--- a/test/uk/gov/hmrc/agentaccesscontrol/service/CesaAuthorisationServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentaccesscontrol/service/CesaAuthorisationServiceSpec.scala
@@ -19,8 +19,6 @@ package uk.gov.hmrc.agentaccesscontrol.service
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import uk.gov.hmrc.agentaccesscontrol.audit.AgentAccessControlEvent.CESA_Decision
-import uk.gov.hmrc.agentaccesscontrol.audit.{AgentAccessControlEvent, AuditService}
 import uk.gov.hmrc.agentaccesscontrol.connectors.desapi.DesAgentClientApiConnector
 import uk.gov.hmrc.agentaccesscontrol.model.{FoundResponse, NotFoundResponse}
 import uk.gov.hmrc.domain.{AgentCode, SaAgentReference, SaUtr}
@@ -44,7 +42,6 @@ class CesaAuthorisationServiceSpec extends UnitSpec with MockitoSugar {
         thenReturn(NotFoundResponse)
 
       await(service.isAuthorisedInCesa(agentCode, saAgentRef, clientSaUtr)) shouldBe false
-      verify(mockAuditService).auditEvent(CESA_Decision, agentCode, clientSaUtr, Seq("result" -> false, "response" -> "not-found"))
     }
 
     "return true if the DES API returns 64-8=true and i64-8=true" in new Context {
@@ -52,7 +49,6 @@ class CesaAuthorisationServiceSpec extends UnitSpec with MockitoSugar {
         thenReturn(FoundResponse(auth64_8 = true, authI64_8 = true))
 
       await(service.isAuthorisedInCesa(agentCode, saAgentRef, clientSaUtr)) shouldBe true
-      verify(mockAuditService).auditEvent(CESA_Decision, agentCode, clientSaUtr, Seq("result" -> true))
     }
 
     "return false if the DES API returns 64-8=true and i64-8=false" in new Context {
@@ -60,7 +56,6 @@ class CesaAuthorisationServiceSpec extends UnitSpec with MockitoSugar {
         thenReturn(FoundResponse(auth64_8 = true, authI64_8 = false))
 
       await(service.isAuthorisedInCesa(agentCode, saAgentRef, clientSaUtr)) shouldBe false
-      verify(mockAuditService).auditEvent(CESA_Decision, agentCode, clientSaUtr, Seq("result" -> false, "64-8" -> true, "i64-8" -> false))
     }
 
     "return false if the DES API returns 64-8=false and i64-8=true" in new Context {
@@ -68,7 +63,6 @@ class CesaAuthorisationServiceSpec extends UnitSpec with MockitoSugar {
         thenReturn(FoundResponse(auth64_8 = false, authI64_8 = true))
 
       await(service.isAuthorisedInCesa(agentCode, saAgentRef, clientSaUtr)) shouldBe false
-      verify(mockAuditService).auditEvent(CESA_Decision, agentCode, clientSaUtr, Seq("result" -> false, "64-8" -> false, "i64-8" -> true))
     }
 
     "return false if the DES API returns 64-8=false and i64-8=false" in new Context {
@@ -76,7 +70,6 @@ class CesaAuthorisationServiceSpec extends UnitSpec with MockitoSugar {
         thenReturn(FoundResponse(auth64_8 = false, authI64_8 = false))
 
       await(service.isAuthorisedInCesa(agentCode, saAgentRef, clientSaUtr)) shouldBe false
-      verify(mockAuditService).auditEvent(CESA_Decision, agentCode, clientSaUtr, Seq("result" -> false, "64-8" -> false, "i64-8" -> false))
     }
 
     "propagate any errors that happened" in new Context {
@@ -91,7 +84,6 @@ class CesaAuthorisationServiceSpec extends UnitSpec with MockitoSugar {
 
   private abstract class Context {
     val mockDesAgentClientApiConnector = mock[DesAgentClientApiConnector]
-    val mockAuditService = mock[AuditService]
-    val service = new CesaAuthorisationService(mockDesAgentClientApiConnector, mockAuditService)
+    val service = new CesaAuthorisationService(mockDesAgentClientApiConnector)
   }
 }

--- a/test/uk/gov/hmrc/agentaccesscontrol/service/GovernmentGatewayAuthorisationServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentaccesscontrol/service/GovernmentGatewayAuthorisationServiceSpec.scala
@@ -17,10 +17,9 @@
 package uk.gov.hmrc.agentaccesscontrol.service
 
 import org.mockito.Mockito
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Mockito.when
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.mock.MockitoSugar
-import uk.gov.hmrc.agentaccesscontrol.audit.{AgentAccessControlEvent, AuditService}
 import uk.gov.hmrc.agentaccesscontrol.connectors.{AssignedAgent, AssignedCredentials, GovernmentGatewayProxyConnector}
 import uk.gov.hmrc.domain.{AgentCode, SaUtr}
 import uk.gov.hmrc.play.http.HeaderCarrier
@@ -31,8 +30,7 @@ import scala.concurrent.Future
 class GovernmentGatewayAuthorisationServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfterEach {
 
   val ggProxyConnector = mock[GovernmentGatewayProxyConnector]
-  val auditService = mock[AuditService]
-  val service = new GovernmentGatewayAuthorisationService(ggProxyConnector, auditService)
+  val service = new GovernmentGatewayAuthorisationService(ggProxyConnector)
   val agentCode = AgentCode("12AAAAA3A456")
   val agentCode2 = AgentCode("23BBBBB4B567")
   val utr = SaUtr("0123456789")
@@ -47,7 +45,6 @@ class GovernmentGatewayAuthorisationServiceSpec extends UnitSpec with MockitoSug
       val result = await(service.isAuthorisedInGovernmentGateway(agentCode, "000111333", utr))
 
       result shouldBe true
-      verify(auditService).auditEvent(AgentAccessControlEvent.GGW_Decision, agentCode, utr, Seq("ggCredentialId" -> "000111333", "result" -> true))
     }
 
     "return true if there is more than one agent assigned to the client" in {
@@ -57,7 +54,6 @@ class GovernmentGatewayAuthorisationServiceSpec extends UnitSpec with MockitoSug
       val result = await(service.isAuthorisedInGovernmentGateway(agentCode, "000111444", utr))
 
       result shouldBe true
-      verify(auditService).auditEvent(AgentAccessControlEvent.GGW_Decision, agentCode, utr, Seq("ggCredentialId" -> "000111444", "result" -> true))
     }
 
     "return false if the client is allocated to the agency but not assigned to the agent credential" in {
@@ -67,7 +63,6 @@ class GovernmentGatewayAuthorisationServiceSpec extends UnitSpec with MockitoSug
       val result = await(service.isAuthorisedInGovernmentGateway(agentCode, "000111333", utr))
 
       result shouldBe false
-      verify(auditService).auditEvent(AgentAccessControlEvent.GGW_Decision, agentCode, utr, Seq("ggCredentialId" -> "000111333", "result" -> false))
     }
 
     // we don't expect the GG to allow things to be set up like this, so this test is just here to be on the safe side
@@ -78,7 +73,6 @@ class GovernmentGatewayAuthorisationServiceSpec extends UnitSpec with MockitoSug
       val result = await(service.isAuthorisedInGovernmentGateway(agentCode, "000111333", utr))
 
       result shouldBe false
-      verify(auditService).auditEvent(AgentAccessControlEvent.GGW_Decision, agentCode, utr, Seq("ggCredentialId" -> "000111333", "result" -> false))
     }
 
     // we don't expect the GG to allow things to be set up like this, so this test is just here to be on the safe side
@@ -91,7 +85,6 @@ class GovernmentGatewayAuthorisationServiceSpec extends UnitSpec with MockitoSug
       val result = await(service.isAuthorisedInGovernmentGateway(agentCode, "000111333", utr))
 
       result shouldBe false
-      verify(auditService).auditEvent(AgentAccessControlEvent.GGW_Decision, agentCode, utr, Seq("ggCredentialId" -> "000111333", "result" -> false))
     }
 
     "return false if the client is neither allocated to the agency nor assigned to the agent credential" in {
@@ -101,7 +94,6 @@ class GovernmentGatewayAuthorisationServiceSpec extends UnitSpec with MockitoSug
       val result = await(service.isAuthorisedInGovernmentGateway(agentCode, "NonMatchingCred", utr))
 
       result shouldBe false
-      verify(auditService).auditEvent(AgentAccessControlEvent.GGW_Decision, agentCode, utr, Seq("ggCredentialId" -> "NonMatchingCred", "result" -> false))
     }
 
     "return true if the client is allocated to more than one agency, and one of them is matching" in {
@@ -111,7 +103,6 @@ class GovernmentGatewayAuthorisationServiceSpec extends UnitSpec with MockitoSug
           AssignedAgent(agentCode2, Seq(AssignedCredentials("000111444")))))
 
       await(service.isAuthorisedInGovernmentGateway(agentCode2, "000111444", utr)) shouldBe true
-      verify(auditService).auditEvent(AgentAccessControlEvent.GGW_Decision, agentCode2, utr, Seq("ggCredentialId" -> "000111444", "result" -> true))
     }
 
     "throw exception if government gateway proxy fails" in {
@@ -122,6 +113,6 @@ class GovernmentGatewayAuthorisationServiceSpec extends UnitSpec with MockitoSug
   }
 
   override protected def beforeEach(): Unit = {
-    Mockito.reset(auditService, ggProxyConnector)
+    Mockito.reset(ggProxyConnector)
   }
 }


### PR DESCRIPTION
* Replace CESA_Response audit event with implicit OutboundCall auditing
* Remove GGW_Response audit events
* Remove GGW_Decision audit events
* Remove CESA_Decision audit events

See individual commit messages for rationale.

984b1a33beaa3606c9fcae8d8033f2b164290f1f turned out not to be necessary in the end - I think it's an improvement but can remove it if required.