### PR TITLE
[FD] Don't start up a TestServer in tests that don't need it

### DIFF
--- a/it/uk/gov/hmrc/agentaccesscontrol/AuthorisationControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentaccesscontrol/AuthorisationControllerISpec.scala
@@ -19,11 +19,11 @@ package uk.gov.hmrc.agentaccesscontrol
 import com.kenshoo.play.metrics.MetricsRegistry
 import uk.gov.hmrc.agentaccesscontrol.audit.AgentAccessControlEvent.AgentAccessControlDecision
 import uk.gov.hmrc.agentaccesscontrol.stubs.DataStreamStub
-import uk.gov.hmrc.agentaccesscontrol.support.{BaseISpec, Resource}
+import uk.gov.hmrc.agentaccesscontrol.support.{Resource, WireMockWithOneServerPerSuiteISpec}
 import uk.gov.hmrc.domain.{AgentCode, SaAgentReference, SaUtr}
 import uk.gov.hmrc.play.http.HttpResponse
 
-class AuthorisationControllerISpec extends BaseISpec {
+class AuthorisationControllerISpec extends WireMockWithOneServerPerSuiteISpec {
 
   val agentCode = AgentCode("ABCDEF123456")
   val saAgentReference = SaAgentReference("ABC456")

--- a/it/uk/gov/hmrc/agentaccesscontrol/MtdAuthorisationISpec.scala
+++ b/it/uk/gov/hmrc/agentaccesscontrol/MtdAuthorisationISpec.scala
@@ -1,11 +1,11 @@
 package uk.gov.hmrc.agentaccesscontrol
 
 import uk.gov.hmrc.agentaccesscontrol.model.{Arn, MtdSaClientId}
-import uk.gov.hmrc.agentaccesscontrol.support.{BaseISpec, Resource}
+import uk.gov.hmrc.agentaccesscontrol.support.{Resource, WireMockWithOneServerPerSuiteISpec}
 import uk.gov.hmrc.domain.AgentCode
 import uk.gov.hmrc.play.http.HttpResponse
 
-class MtdAuthorisationISpec extends BaseISpec {
+class MtdAuthorisationISpec extends WireMockWithOneServerPerSuiteISpec {
   val agentCode = AgentCode("A11112222A")
   val arn = Arn("01234567890")
   val clientId = MtdSaClientId("12345677890")

--- a/it/uk/gov/hmrc/agentaccesscontrol/WhitelistISpec.scala
+++ b/it/uk/gov/hmrc/agentaccesscontrol/WhitelistISpec.scala
@@ -18,11 +18,11 @@ package uk.gov.hmrc.agentaccesscontrol
 
 import java.util.Base64
 
-import uk.gov.hmrc.agentaccesscontrol.support.{BaseISpec, Resource}
+import uk.gov.hmrc.agentaccesscontrol.support.{Resource, WireMockWithOneServerPerSuiteISpec}
 import uk.gov.hmrc.domain.{AgentCode, SaAgentReference, SaUtr}
 import uk.gov.hmrc.play.http.HttpResponse
 
-class WhitelistISpec extends BaseISpec {
+class WhitelistISpec extends WireMockWithOneServerPerSuiteISpec {
 
   val agentCode = AgentCode("ABCDEF123456")
   val saAgentReference = SaAgentReference("ABC456")

--- a/it/uk/gov/hmrc/agentaccesscontrol/connectors/AuthConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentaccesscontrol/connectors/AuthConnectorISpec.scala
@@ -20,12 +20,15 @@ import java.net.URL
 
 import com.kenshoo.play.metrics.MetricsRegistry
 import uk.gov.hmrc.agentaccesscontrol.WSHttp
-import uk.gov.hmrc.agentaccesscontrol.support.BaseISpec
+import uk.gov.hmrc.agentaccesscontrol.support.WireMockWithOneAppPerSuiteISpec
 import uk.gov.hmrc.domain.SaAgentReference
+import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class AuthConnectorISpec extends BaseISpec {
+class AuthConnectorISpec extends WireMockWithOneAppPerSuiteISpec {
+
+  implicit val hc = HeaderCarrier()
 
   "getSaAgentReference" should {
     "return sa agent reference and other auth details" in {

--- a/it/uk/gov/hmrc/agentaccesscontrol/connectors/GovernmentGatewayProxyConnectorSpec.scala
+++ b/it/uk/gov/hmrc/agentaccesscontrol/connectors/GovernmentGatewayProxyConnectorSpec.scala
@@ -5,13 +5,15 @@ import java.net.URL
 import com.kenshoo.play.metrics.MetricsRegistry
 import org.scalatest.mock.MockitoSugar
 import uk.gov.hmrc.agentaccesscontrol.WSHttp
-import uk.gov.hmrc.agentaccesscontrol.support.BaseISpec
+import uk.gov.hmrc.agentaccesscontrol.support.WireMockWithOneAppPerSuiteISpec
 import uk.gov.hmrc.domain.{AgentCode, SaUtr}
-import uk.gov.hmrc.play.http.Upstream5xxResponse
+import uk.gov.hmrc.play.http.{HeaderCarrier, Upstream5xxResponse}
 
 import scala.xml.SAXParseException
 
-class GovernmentGatewayProxyConnectorSpec extends BaseISpec with MockitoSugar {
+class GovernmentGatewayProxyConnectorSpec extends WireMockWithOneAppPerSuiteISpec with MockitoSugar {
+
+  implicit val hc = HeaderCarrier()
 
   val agentCode = AgentCode("AgentCode")
   val connector = new GovernmentGatewayProxyConnector(new URL(wiremockBaseUrl), WSHttp)

--- a/it/uk/gov/hmrc/agentaccesscontrol/connectors/desapi/DesAgentClientApiConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentaccesscontrol/connectors/desapi/DesAgentClientApiConnectorISpec.scala
@@ -25,7 +25,7 @@ import org.scalatest.mock.MockitoSugar
 import play.api.libs.json.Json
 import uk.gov.hmrc.agentaccesscontrol.WSHttp
 import uk.gov.hmrc.agentaccesscontrol.model.{DesAgentClientFlagsApiResponse, FoundResponse, NotFoundResponse}
-import uk.gov.hmrc.agentaccesscontrol.support.BaseISpec
+import uk.gov.hmrc.agentaccesscontrol.support.WireMockWithOneAppPerSuiteISpec
 import uk.gov.hmrc.domain.{AgentCode, SaAgentReference, SaUtr}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.model.MergedDataEvent
@@ -34,7 +34,7 @@ import uk.gov.hmrc.play.http.HeaderCarrier
 import scala.concurrent.ExecutionContext
 
 
-class DesAgentClientApiConnectorISpec extends BaseISpec with MockitoSugar {
+class DesAgentClientApiConnectorISpec extends WireMockWithOneAppPerSuiteISpec with MockitoSugar {
 
   implicit val headerCarrier = HeaderCarrier()
   val agentCode = AgentCode("Agent")

--- a/it/uk/gov/hmrc/agentaccesscontrol/support/BaseISpec.scala
+++ b/it/uk/gov/hmrc/agentaccesscontrol/support/BaseISpec.scala
@@ -17,51 +17,50 @@
 package uk.gov.hmrc.agentaccesscontrol.support
 
 import com.github.tomakehurst.wiremock.client.WireMock._
-import org.scalatestplus.play.OneServerPerSuite
+import org.scalatestplus.play.{OneAppPerSuite, OneServerPerSuite}
 import play.api.test.FakeApplication
 import uk.gov.hmrc.agentaccesscontrol.StartAndStopWireMock
 import uk.gov.hmrc.agentaccesscontrol.model.{Arn, MtdSaClientId}
 import uk.gov.hmrc.domain.{AgentCode, SaAgentReference, SaUtr}
-import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.test.UnitSpec
 
-abstract class BaseISpec extends UnitSpec
-    with StartAndStopWireMock
-    with StubUtils
-    with OneServerPerSuite {
+abstract class WireMockISpec extends UnitSpec
+  with StartAndStopWireMock
+  with StubUtils {
 
-  private val configDesHost = "microservice.services.des.host"
-  private val configDesPort = "microservice.services.des.port"
-  private val configAuthHost = "microservice.services.auth.host"
-  private val configAuthPort = "microservice.services.auth.port"
-  private val ggProxyHost = "microservice.services.government-gateway-proxy.host"
-  private val ggProxyPort = "microservice.services.government-gateway-proxy.port"
-  private val auditingHost = "auditing.consumer.baseUri.host"
-  private val auditingPort = "auditing.consumer.baseUri.port"
-  private val agenciesHost = "microservice.services.agencies-fake.host"
-  private val agenciesPort = "microservice.services.agencies-fake.port"
-  private val relationshipsHost = "microservice.services.agent-client-relationships.host"
-  private val relationshipsPort = "microservice.services.agent-client-relationships.port"
+  protected val wireMockAppConfiguration: Map[String, Any] = Map(
+    "microservice.services.des.host" -> wiremockHost,
+    "microservice.services.des.port" -> wiremockPort,
+    "microservice.services.auth.host" -> wiremockHost,
+    "microservice.services.auth.port" -> wiremockPort,
+    "microservice.services.government-gateway-proxy.host" -> wiremockHost,
+    "microservice.services.government-gateway-proxy.port" -> wiremockPort,
+    "auditing.consumer.baseUri.host" -> wiremockHost,
+    "auditing.consumer.baseUri.port" -> wiremockPort,
+    "microservice.services.agencies-fake.host" -> wiremockHost,
+    "microservice.services.agencies-fake.port" -> wiremockPort,
+    "microservice.services.agent-client-relationships.host" -> wiremockHost,
+    "microservice.services.agent-client-relationships.port" -> wiremockPort
+  )
+}
 
-  implicit val hc = HeaderCarrier()
+abstract class WireMockWithOneAppPerSuiteISpec extends WireMockISpec
+  with OneAppPerSuite {
 
   protected def additionalConfiguration: Map[String, String] = Map.empty
 
   override implicit lazy val app: FakeApplication = FakeApplication(
-    additionalConfiguration = Map(
-      configDesHost -> wiremockHost,
-      configDesPort -> wiremockPort,
-      configAuthHost -> wiremockHost,
-      configAuthPort -> wiremockPort,
-      ggProxyHost -> wiremockHost,
-      ggProxyPort -> wiremockPort,
-      auditingHost -> wiremockHost,
-      auditingPort -> wiremockPort,
-      agenciesHost -> wiremockHost,
-      agenciesPort -> wiremockPort,
-      relationshipsHost -> wiremockHost,
-      relationshipsPort -> wiremockPort
-    ) ++ additionalConfiguration
+    additionalConfiguration = wireMockAppConfiguration ++ additionalConfiguration
+  )
+}
+
+abstract class WireMockWithOneServerPerSuiteISpec extends WireMockISpec
+  with OneServerPerSuite {
+
+  protected def additionalConfiguration: Map[String, String] = Map.empty
+
+  override implicit lazy val app: FakeApplication = FakeApplication(
+    additionalConfiguration = wireMockAppConfiguration ++ additionalConfiguration
   )
 }
 


### PR DESCRIPTION
Tests like DesAgentClientApiConnectorISpec don't need to make HTTP requests to a running version of the application, so don't indirectly inherit OneServerPerSuite to avoid starting up an unnecessary TestServer.

Also push the implicit HeaderCarrier down to the tests that need it to avoid surprises and make wireMockAppConfiguration easier to read by inlining only-used-once constants.