### PR TITLE
[FD][APB-505] Set DES URL to production URL, not QA/ist0 URL

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -187,7 +187,7 @@ Prod.microservice.services {
 
     des {
         protocol=https
-        host=des.ws.ibt.hmrc.gov.uk
+        host=des.ws.hmrc.gov.uk
         port=443
         authorization-token=secret
         environment=noenv


### PR DESCRIPTION
QA and prod DES URLs are different, so we are putting the prod URL in application.conf and the QA URL in app-config-qa.