### PR TITLE
APB-7224 [CS] update TSG excluded clients auth to support uk cbc

### DIFF
--- a/app/uk/gov/hmrc/agentaccesscontrol/service/ESAuthorisationService.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/service/ESAuthorisationService.scala
@@ -29,7 +29,6 @@ import uk.gov.hmrc.agentaccesscontrol.connectors.mtd.RelationshipsConnector
 import uk.gov.hmrc.agentaccesscontrol.model.AuthDetails
 import uk.gov.hmrc.agentmtdidentifiers.model.{
   Arn,
-  EnrolmentKey,
   TrustTaxIdentifier,
   Urn,
   Utr
@@ -254,8 +253,7 @@ class ESAuthorisationService @Inject()(
             .map(_.id)
             .contains(userId)
           val isClientExcluded = taxGroup.excludedClients
-            .exists(_.enrolmentKey == EnrolmentKey
-              .enrolmentKey(serviceId = regime, clientId = taxIdentifier.value))
+            .exists(_.enrolmentKey.contains(taxIdentifier.value))
           isUserIdInTaxServiceGroup && !isClientExcluded
         case None => false
       }


### PR DESCRIPTION
We don't need to validate the regime with a strict enrolment key match, because it won't find if it pulls back the wrong tax service group. 