### PR TITLE
APB-8656 Added support for mtd-it-auth-supp rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ authorised(
      .withDelegatedAuthRule("mtd-it-auth")) { /* your protected logic */ }
 ```
 
+##### GET /agent-access-control/mtd-it-auth-supp/agent/:agentCode/client/:mtdItId
+
+### Example usage
+```scala
+authorised(
+   Enrolment("HMRC-MTD-IT-SUPP")
+     .withIdentifier("MTDITID", "123")
+     .withDelegatedAuthRule("mtd-it-auth-supp")) { /* your protected logic */ }
+```
+
 ##### GET /agent-access-control/mtd-vat-auth/agent/:agentCode/client/:vrn
 
 ### Example usage

--- a/app/uk/gov/hmrc/agentaccesscontrol/controllers/AuthorisationController.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/controllers/AuthorisationController.scala
@@ -55,7 +55,7 @@ class AuthorisationController @Inject() (
     Action.async { implicit request: Request[_] =>
       withAgentAuthorised(AgentCode(agentCode)) { authDetails =>
         def standardAuth(service: Service, taxId: TaxIdentifier): Future[AccessResponse] =
-          esAuthorisationService.authoriseStandardService(AgentCode(agentCode), taxId, service.id, authDetails)
+          esAuthorisationService.authoriseStandardService(AgentCode(agentCode), taxId, service, authDetails)
         val urnPattern = "^((?i)[a-z]{2}trust[0-9]{8})$"
         val utrPattern = "^\\d{10}$"
 
@@ -72,8 +72,9 @@ class AuthorisationController @Inject() (
           case "afi-auth" =>
             authorisationService.isAuthorisedForAfi(AgentCode(agentCode), Nino(clientId), authDetails)
           // Standard cases
-          case "mtd-it-auth"  => standardAuth(Service.MtdIt, MtdItId(clientId))
-          case "mtd-vat-auth" => standardAuth(Service.Vat, Vrn(clientId))
+          case "mtd-it-auth"      => standardAuth(Service.MtdIt, MtdItId(clientId))
+          case "mtd-it-auth-supp" => standardAuth(Service.MtdItSupp, MtdItId(clientId))
+          case "mtd-vat-auth"     => standardAuth(Service.Vat, Vrn(clientId))
           case "trust-auth" if clientId.matches(utrPattern) =>
             standardAuth(Service.Trust, Utr(clientId))
           case "trust-auth" if clientId.matches(urnPattern) =>

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import CodeCoverageSettings.scoverageSettings
 import uk.gov.hmrc.DefaultBuildSettings
 
 ThisBuild / majorVersion := 1
@@ -24,6 +25,7 @@ lazy val microservice = (project in file("."))
     PlayKeys.playDefaultPort := 9431,
     resolvers ++= Seq(Resolver.typesafeRepo("releases")),
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
+    scoverageSettings,
     Compile / unmanagedResourceDirectories += baseDirectory.value / "resources",
     Compile / scalafmtOnCompile := true,
     Test / scalafmtOnCompile := true,

--- a/it/test/uk/gov/hmrc/agentaccesscontrol/connectors/mtd/RelationshipsConnectorISpec.scala
+++ b/it/test/uk/gov/hmrc/agentaccesscontrol/connectors/mtd/RelationshipsConnectorISpec.scala
@@ -23,6 +23,7 @@ import uk.gov.hmrc.agentaccesscontrol.stubs.AgentClientRelationshipStub
 import uk.gov.hmrc.agentaccesscontrol.utils.ComponentSpecHelper
 import uk.gov.hmrc.agentaccesscontrol.utils.MetricTestSupport
 import uk.gov.hmrc.agentaccesscontrol.utils.TestConstants._
+import uk.gov.hmrc.agentmtdidentifiers.model.Service
 import uk.gov.hmrc.http.HeaderCarrier
 
 class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSupport with AgentClientRelationshipStub {
@@ -35,7 +36,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubMtdItAgentClientRelationship(testArn, testMtdItId)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testMtdItId)) shouldBe true
+      await(connector.relationshipExists(testArn, None, testMtdItId, Service.MtdIt)) shouldBe true
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckMtdItId-GET")
     }
 
@@ -43,7 +44,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubMtdItAgentClientRelationship(testArn, testMtdItId)(NOT_FOUND)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testMtdItId)) shouldBe false
+      await(connector.relationshipExists(testArn, None, testMtdItId, Service.MtdIt)) shouldBe false
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckMtdItId-GET")
     }
 
@@ -52,7 +53,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       cleanMetricRegistry()
 
       intercept[Exception] {
-        await(connector.relationshipExists(testArn, None, testMtdItId))
+        await(connector.relationshipExists(testArn, None, testMtdItId, Service.MtdIt))
       }.getMessage should include("300")
     }
 
@@ -60,7 +61,43 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubMtdItAgentClientRelationship(testArn, testMtdItId)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testMtdItId))
+      await(connector.relationshipExists(testArn, None, testMtdItId, Service.MtdIt))
+
+      timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckMtdItId-GET")
+    }
+  }
+
+  "relationshipExists for HMRC-MTD-IT-SUPP" should {
+    "return true when relationship exists" in {
+      stubMtdItSuppAgentClientRelationship(testArn, testMtdItId)(OK)
+      cleanMetricRegistry()
+
+      await(connector.relationshipExists(testArn, None, testMtdItId, Service.MtdItSupp)) shouldBe true
+      timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckMtdItId-GET")
+    }
+
+    "return false when relationship does not exist" in {
+      stubMtdItSuppAgentClientRelationship(testArn, testMtdItId)(NOT_FOUND)
+      cleanMetricRegistry()
+
+      await(connector.relationshipExists(testArn, None, testMtdItId, Service.MtdItSupp)) shouldBe false
+      timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckMtdItId-GET")
+    }
+
+    "throw exception when unexpected status code encountered" in {
+      stubMtdItSuppAgentClientRelationship(testArn, testMtdItId)(MULTIPLE_CHOICES)
+      cleanMetricRegistry()
+
+      intercept[Exception] {
+        await(connector.relationshipExists(testArn, None, testMtdItId, Service.MtdItSupp))
+      }.getMessage should include("300")
+    }
+
+    "record metrics" in {
+      stubMtdItSuppAgentClientRelationship(testArn, testMtdItId)(OK)
+      cleanMetricRegistry()
+
+      await(connector.relationshipExists(testArn, None, testMtdItId, Service.MtdItSupp))
 
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckMtdItId-GET")
     }
@@ -71,7 +108,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubMtdVatAgentClientRelationship(testArn, testVrn)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testVrn)) shouldBe true
+      await(connector.relationshipExists(testArn, None, testVrn, Service.Vat)) shouldBe true
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckVrn-GET")
     }
 
@@ -79,7 +116,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubMtdVatAgentClientRelationship(testArn, testVrn)(NOT_FOUND)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testVrn)) shouldBe false
+      await(connector.relationshipExists(testArn, None, testVrn, Service.Vat)) shouldBe false
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckVrn-GET")
     }
 
@@ -88,7 +125,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       cleanMetricRegistry()
 
       intercept[Exception] {
-        await(connector.relationshipExists(testArn, None, testVrn))
+        await(connector.relationshipExists(testArn, None, testVrn, Service.Vat))
       }.getMessage should include("300")
     }
 
@@ -96,7 +133,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubMtdVatAgentClientRelationship(testArn, testVrn)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testVrn))
+      await(connector.relationshipExists(testArn, None, testVrn, Service.Vat))
 
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckVrn-GET")
     }
@@ -107,7 +144,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubTersAgentClientRelationship(testArn, testUtr)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testUtr)) shouldBe true
+      await(connector.relationshipExists(testArn, None, testUtr, Service.Trust)) shouldBe true
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckUtr-GET")
     }
 
@@ -115,7 +152,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubTersAgentClientRelationship(testArn, testUtr)(NOT_FOUND)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testUtr)) shouldBe false
+      await(connector.relationshipExists(testArn, None, testUtr, Service.Trust)) shouldBe false
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckUtr-GET")
     }
 
@@ -124,7 +161,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       cleanMetricRegistry()
 
       intercept[Exception] {
-        await(connector.relationshipExists(testArn, None, testUtr))
+        await(connector.relationshipExists(testArn, None, testUtr, Service.Trust))
       }.getMessage should include("300")
     }
 
@@ -132,7 +169,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubTersAgentClientRelationship(testArn, testUtr)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testUtr))
+      await(connector.relationshipExists(testArn, None, testUtr, Service.Trust))
 
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckUtr-GET")
     }
@@ -143,7 +180,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubTersntAgentClientRelationship(testArn, testUrn)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testUrn)) shouldBe true
+      await(connector.relationshipExists(testArn, None, testUrn, Service.TrustNT)) shouldBe true
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckUrn-GET")
     }
 
@@ -151,7 +188,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubTersntAgentClientRelationship(testArn, testUrn)(NOT_FOUND)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testUrn)) shouldBe false
+      await(connector.relationshipExists(testArn, None, testUrn, Service.TrustNT)) shouldBe false
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckUrn-GET")
     }
 
@@ -160,7 +197,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       cleanMetricRegistry()
 
       intercept[Exception] {
-        await(connector.relationshipExists(testArn, None, testUrn))
+        await(connector.relationshipExists(testArn, None, testUrn, Service.TrustNT))
       }.getMessage should include("300")
     }
 
@@ -168,7 +205,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubTersntAgentClientRelationship(testArn, testUrn)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testUrn))
+      await(connector.relationshipExists(testArn, None, testUrn, Service.TrustNT))
 
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckUrn-GET")
     }
@@ -179,7 +216,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubCgtAgentClientRelationship(testArn, testCgtRef)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testCgtRef)) shouldBe true
+      await(connector.relationshipExists(testArn, None, testCgtRef, Service.CapitalGains)) shouldBe true
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckCgtRef-GET")
     }
 
@@ -187,7 +224,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubCgtAgentClientRelationship(testArn, testCgtRef)(NOT_FOUND)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testCgtRef)) shouldBe false
+      await(connector.relationshipExists(testArn, None, testCgtRef, Service.CapitalGains)) shouldBe false
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckCgtRef-GET")
     }
 
@@ -196,7 +233,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       cleanMetricRegistry()
 
       intercept[Exception] {
-        await(connector.relationshipExists(testArn, None, testCgtRef))
+        await(connector.relationshipExists(testArn, None, testCgtRef, Service.CapitalGains))
       }.getMessage should include("300")
     }
 
@@ -204,7 +241,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubCgtAgentClientRelationship(testArn, testCgtRef)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testCgtRef))
+      await(connector.relationshipExists(testArn, None, testCgtRef, Service.CapitalGains))
 
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckCgtRef-GET")
     }
@@ -215,7 +252,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubPptAgentClientRelationship(testArn, testPptRef)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testPptRef)) shouldBe true
+      await(connector.relationshipExists(testArn, None, testPptRef, Service.Ppt)) shouldBe true
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckPptRef-GET")
     }
 
@@ -223,7 +260,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubPptAgentClientRelationship(testArn, testPptRef)(NOT_FOUND)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testPptRef)) shouldBe false
+      await(connector.relationshipExists(testArn, None, testPptRef, Service.Ppt)) shouldBe false
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckPptRef-GET")
     }
 
@@ -232,7 +269,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       cleanMetricRegistry()
 
       intercept[Exception] {
-        await(connector.relationshipExists(testArn, None, testPptRef))
+        await(connector.relationshipExists(testArn, None, testPptRef, Service.Ppt))
       }.getMessage should include("300")
     }
 
@@ -240,7 +277,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubPptAgentClientRelationship(testArn, testPptRef)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testPptRef))
+      await(connector.relationshipExists(testArn, None, testPptRef, Service.Ppt))
 
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckPptRef-GET")
     }
@@ -251,7 +288,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubCbcIdAgentClientRelationship(testArn, testCbcId)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testCbcId)) shouldBe true
+      await(connector.relationshipExists(testArn, None, testCbcId, Service.Cbc)) shouldBe true
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckCbcId-GET")
     }
 
@@ -259,7 +296,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubCbcIdAgentClientRelationship(testArn, testCbcId)(NOT_FOUND)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testCbcId)) shouldBe false
+      await(connector.relationshipExists(testArn, None, testCbcId, Service.Cbc)) shouldBe false
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckCbcId-GET")
     }
 
@@ -268,7 +305,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       cleanMetricRegistry()
 
       intercept[Exception] {
-        await(connector.relationshipExists(testArn, None, testCbcId))
+        await(connector.relationshipExists(testArn, None, testCbcId, Service.Cbc))
       }.getMessage should include("300")
     }
 
@@ -276,7 +313,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubCbcIdAgentClientRelationship(testArn, testCbcId)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testCbcId))
+      await(connector.relationshipExists(testArn, None, testCbcId, Service.Cbc))
 
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckCbcId-GET")
     }
@@ -287,7 +324,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubPlrIdAgentClientRelationship(testArn, testPlrId)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testPlrId)) shouldBe true
+      await(connector.relationshipExists(testArn, None, testPlrId, Service.Pillar2)) shouldBe true
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckPlrId-GET")
     }
 
@@ -295,7 +332,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubPlrIdAgentClientRelationship(testArn, testPlrId)(NOT_FOUND)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testPlrId)) shouldBe false
+      await(connector.relationshipExists(testArn, None, testPlrId, Service.Pillar2)) shouldBe false
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckPlrId-GET")
     }
 
@@ -304,7 +341,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       cleanMetricRegistry()
 
       intercept[Exception] {
-        await(connector.relationshipExists(testArn, None, testPlrId))
+        await(connector.relationshipExists(testArn, None, testPlrId, Service.Pillar2))
       }.getMessage should include("300")
     }
 
@@ -312,7 +349,7 @@ class RelationshipsConnectorISpec extends ComponentSpecHelper with MetricTestSup
       stubPlrIdAgentClientRelationship(testArn, testPlrId)(OK)
       cleanMetricRegistry()
 
-      await(connector.relationshipExists(testArn, None, testPlrId))
+      await(connector.relationshipExists(testArn, None, testPlrId, Service.Pillar2))
 
       timerShouldExistAndHasBeenUpdated(s"ConsumedAPI-AgentClientRelationships-CheckPlrId-GET")
     }

--- a/it/test/uk/gov/hmrc/agentaccesscontrol/stubs/AgentClientRelationshipStub.scala
+++ b/it/test/uk/gov/hmrc/agentaccesscontrol/stubs/AgentClientRelationshipStub.scala
@@ -29,6 +29,12 @@ trait AgentClientRelationshipStub extends WiremockMethods {
       uri = s"/agent-client-relationships/agent/${arn.value}/service/HMRC-MTD-IT/client/MTDITID/${mtdItId.value}"
     ).thenReturn(status)
 
+  def stubMtdItSuppAgentClientRelationship(arn: Arn, mtdItId: MtdItId)(status: Int): StubMapping =
+    when(
+      method = GET,
+      uri = s"/agent-client-relationships/agent/${arn.value}/service/HMRC-MTD-IT-SUPP/client/MTDITID/${mtdItId.value}"
+    ).thenReturn(status)
+
   def stubMtdVatAgentClientRelationship(arn: Arn, vrn: Vrn)(status: Int): StubMapping =
     when(
       method = GET,
@@ -77,6 +83,15 @@ trait AgentClientRelationshipStub extends WiremockMethods {
       method = GET,
       uri =
         s"/agent-client-relationships/agent/${arn.value}/service/HMRC-MTD-IT/client/MTDITID/${mtdItId.value}\\?userId=$providerId"
+    ).thenReturn(status)
+
+  def stubMtdItSuppAgentClientRelationshipToUser(arn: Arn, mtdItId: MtdItId, providerId: String)(
+      status: Int
+  ): StubMapping =
+    when(
+      method = GET,
+      uri =
+        s"/agent-client-relationships/agent/${arn.value}/service/HMRC-MTD-IT-SUPP/client/MTDITID/${mtdItId.value}\\?userId=$providerId"
     ).thenReturn(status)
 
   def stubMtdVatAgentClientRelationshipToUser(arn: Arn, vrn: Vrn, providerId: String)(status: Int): StubMapping =

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,7 +5,7 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-backend-play-30" % bootstrapVer,
-    "uk.gov.hmrc" %% "agent-mtd-identifiers" % "1.15.0",
+    "uk.gov.hmrc" %% "agent-mtd-identifiers" % "2.1.0",
     "uk.gov.hmrc" %% "play-allowlist-filter" % "1.2.0"
   )
 

--- a/test/uk/gov/hmrc/agentaccesscontrol/controllers/AuthorisationControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentaccesscontrol/controllers/AuthorisationControllerSpec.scala
@@ -293,6 +293,7 @@ class AuthorisationControllerSpec extends UnitSpec {
     // Standard Cases
     val templateTestDataSets: Seq[(String, TaxIdentifier, Service)] = Seq(
       ("mtd-it-auth", MtdItId("1234567890"), Service.MtdIt),
+      ("mtd-it-auth-supp", MtdItId("1234567890"), Service.MtdItSupp),
       ("mtd-vat-auth", Vrn("123456789"), Service.Vat),
       ("trust-auth", Utr("0123456789"), Service.Trust),
       ("trust-auth", Urn("xxtrust12345678"), Service.TrustNT),
@@ -310,7 +311,7 @@ class AuthorisationControllerSpec extends UnitSpec {
             .returns(authResponseMtdAgent)
 
           mockESAuthorisationService
-            .authoriseStandardService(AgentCode(agentCode), testData._2, testData._3.id, mtdAuthDetails)(
+            .authoriseStandardService(AgentCode(agentCode), testData._2, testData._3, mtdAuthDetails)(
               *[HeaderCarrier],
               *[Request[Any]]
             )
@@ -326,7 +327,7 @@ class AuthorisationControllerSpec extends UnitSpec {
             .authorise(*[Predicate], *[Retrieval[Any]])(*[HeaderCarrier], *[ExecutionContext])
             .returns(authResponseMtdAgent)
           mockESAuthorisationService
-            .authoriseStandardService(AgentCode(agentCode), testData._2, testData._3.id, mtdAuthDetails)(
+            .authoriseStandardService(AgentCode(agentCode), testData._2, testData._3, mtdAuthDetails)(
               *[HeaderCarrier],
               *[Request[Any]]
             )
@@ -342,7 +343,7 @@ class AuthorisationControllerSpec extends UnitSpec {
             .authorise(*[Predicate], *[Retrieval[Any]])(*[HeaderCarrier], *[ExecutionContext])
             .returns(authResponseMtdAgent)
           mockESAuthorisationService
-            .authoriseStandardService(AgentCode(agentCode), testData._2, testData._3.id, mtdAuthDetails)(
+            .authoriseStandardService(AgentCode(agentCode), testData._2, testData._3, mtdAuthDetails)(
               *[HeaderCarrier],
               *[Request[Any]]
             )
@@ -358,7 +359,7 @@ class AuthorisationControllerSpec extends UnitSpec {
             .authorise(*[Predicate], *[Retrieval[Any]])(*[HeaderCarrier], *[ExecutionContext])
             .returns(authResponseMtdAgent)
           mockESAuthorisationService
-            .authoriseStandardService(AgentCode(agentCode), testData._2, testData._3.id, mtdAuthDetails)(
+            .authoriseStandardService(AgentCode(agentCode), testData._2, testData._3, mtdAuthDetails)(
               *[HeaderCarrier],
               *[Request[Any]]
             )

--- a/test/uk/gov/hmrc/agentaccesscontrol/services/ESAuthorisationServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentaccesscontrol/services/ESAuthorisationServiceSpec.scala
@@ -79,6 +79,7 @@ class ESAuthorisationServiceSpec extends UnitSpec {
 
   private val templateTestDataSets: Seq[(Service, TaxIdentifier, String, String)] = Seq(
     (Service.MtdIt, MtdItId("clientId"), "ITSA", Service.MtdIt.id),
+    (Service.MtdItSupp, MtdItId("clientId"), "ITSA", Service.MtdItSupp.id),
     (Service.Vat, Vrn("vrn"), "ALL", Service.Vat.id),
     (Service.Trust, Utr("utr"), "TRS", "HMRC-TERS"),
     (Service.TrustNT, Urn("urn"), "TRS", "HMRC-TERS"),
@@ -108,17 +109,17 @@ class ESAuthorisationServiceSpec extends UnitSpec {
           .getTaxServiceGroups(arn, testData._4)
           .returns(Future.successful(None))
         mockRelationshipsConnector
-          .relationshipExists(arn, None, testData._2)
+          .relationshipExists(arn, None, testData._2, testData._1)
           .returns(Future.successful(true))
         mockRelationshipsConnector
-          .relationshipExists(arn, Some(mtdAuthDetails.ggCredentialId), testData._2)
+          .relationshipExists(arn, Some(mtdAuthDetails.ggCredentialId), testData._2, testData._1)
           .returns(Future.successful(true))
         mockAgentClientAuthorisationConnector
           .getSuspensionDetails(arn)
           .returns(Future.successful(SuspensionDetails.notSuspended))
 
         val result: AccessResponse =
-          await(TestService.authoriseStandardService(agentCode, testData._2, testData._1.id, mtdAuthDetails))
+          await(TestService.authoriseStandardService(agentCode, testData._2, testData._1, mtdAuthDetails))
 
         result mustBe AccessResponse.Authorised
       }
@@ -136,7 +137,7 @@ class ESAuthorisationServiceSpec extends UnitSpec {
           .returns(Future.successful(Success))
 
         val result: AccessResponse =
-          await(TestService.authoriseStandardService(agentCode, testData._2, testData._1.id, nonMtdAuthDetails))
+          await(TestService.authoriseStandardService(agentCode, testData._2, testData._1, nonMtdAuthDetails))
 
         result mustBe AccessResponse.NoRelationship
       }
@@ -156,14 +157,14 @@ class ESAuthorisationServiceSpec extends UnitSpec {
           )
           .returns(Future.successful(Success))
         mockRelationshipsConnector
-          .relationshipExists(arn, None, testData._2)
+          .relationshipExists(arn, None, testData._2, testData._1)
           .returns(Future.successful(false))
         mockAgentClientAuthorisationConnector
           .getSuspensionDetails(arn)
           .returns(Future.successful(SuspensionDetails.notSuspended))
 
         val result: AccessResponse =
-          await(TestService.authoriseStandardService(agentCode, testData._2, testData._1.id, mtdAuthDetails))
+          await(TestService.authoriseStandardService(agentCode, testData._2, testData._1, mtdAuthDetails))
 
         result mustBe AccessResponse.NoRelationship
       }
@@ -180,10 +181,10 @@ class ESAuthorisationServiceSpec extends UnitSpec {
           )
           .returns(Future.successful(Success))
         mockRelationshipsConnector
-          .relationshipExists(arn, None, testData._2)
+          .relationshipExists(arn, None, testData._2, testData._1)
           .returns(Future.successful(true))
         mockRelationshipsConnector
-          .relationshipExists(arn, Some(mtdAuthDetails.ggCredentialId), testData._2)
+          .relationshipExists(arn, Some(mtdAuthDetails.ggCredentialId), testData._2, testData._1)
           .returns(Future.successful(false))
         mockAgentClientAuthorisationConnector
           .getSuspensionDetails(arn)
@@ -197,7 +198,7 @@ class ESAuthorisationServiceSpec extends UnitSpec {
           .returns(Future.successful(None))
 
         val result: AccessResponse =
-          await(TestService.authoriseStandardService(agentCode, testData._2, testData._1.id, mtdAuthDetails))
+          await(TestService.authoriseStandardService(agentCode, testData._2, testData._1, mtdAuthDetails))
 
         result mustBe AccessResponse.NoAssignment
       }
@@ -212,7 +213,7 @@ class ESAuthorisationServiceSpec extends UnitSpec {
           )
 
         val result: AccessResponse =
-          await(TestService.authoriseStandardService(agentCode, testData._2, testData._1.id, mtdAuthDetails))
+          await(TestService.authoriseStandardService(agentCode, testData._2, testData._1, mtdAuthDetails))
 
         result mustBe AccessResponse.AgentSuspended
       }
@@ -248,19 +249,19 @@ class ESAuthorisationServiceSpec extends UnitSpec {
             .successful(None)
         )
       mockRelationshipsConnector
-        .relationshipExists(arn, Some("ggId"), cgtRef)
+        .relationshipExists(arn, Some("ggId"), cgtRef, Service.CapitalGains)
         .returns(
           Future
             .successful(true)
         )
       mockRelationshipsConnector
-        .relationshipExists(arn, None, cgtRef)
+        .relationshipExists(arn, None, cgtRef, Service.CapitalGains)
         .returns(
           Future
             .successful(true)
         )
 
-      await(TestService.authoriseStandardService(agentCode, cgtRef, Service.CapitalGains.id, mtdAuthDetails))
+      await(TestService.authoriseStandardService(agentCode, cgtRef, Service.CapitalGains, mtdAuthDetails))
     }
 
     "when GP outed out, do NOT specify user to check in relationship service call" in new Setup {
@@ -285,13 +286,13 @@ class ESAuthorisationServiceSpec extends UnitSpec {
             .successful(false)
         )
       mockRelationshipsConnector
-        .relationshipExists(arn, None, cgtRef)
+        .relationshipExists(arn, None, cgtRef, Service.CapitalGains)
         .returns(
           Future
             .successful(true)
         )
 
-      await(TestService.authoriseStandardService(agentCode, cgtRef, Service.CapitalGains.id, mtdAuthDetails))
+      await(TestService.authoriseStandardService(agentCode, cgtRef, Service.CapitalGains, mtdAuthDetails))
     }
   }
 


### PR DESCRIPTION
I've had to slightly refactor the relationships connector so that it is passed a service instead of trying to find the service via a reverse lookup with the tax identifier (basically what the TODO comment was already suggesting prior to this).

Also we were defining scoverage settings but I noticed they weren't being used so I've added them to built.sbt.