### PR TITLE
APB-7822 Address unmatched stub calls in ITs, fix Pillar2 suspension bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ authorised(
 
 ```scala
 authorised(
-  Enrolment("HMRC-PILLAR2")
+  Enrolment("HMRC-PILLAR2-ORG")
     .withIdentifier("PLRID", "XYPILLAR21234567890")
     .withDelegatedAuthRule("pillar2-auth") { /* your protected logic */  }
 )

--- a/app/uk/gov/hmrc/agentaccesscontrol/services/ESAuthorisationService.scala
+++ b/app/uk/gov/hmrc/agentaccesscontrol/services/ESAuthorisationService.scala
@@ -122,7 +122,7 @@ class ESAuthorisationService @Inject() (
       case "HMRC-CGT-PD"                         => "CGT"
       case "HMRC-PPT-ORG"                        => "PPT"
       case "HMRC-CBC-ORG" | "HMRC-CBC-NONUK-ORG" => "CBC"
-      case "HMRC-PILLAR2-ORG"                    => "PILLAR2"
+      case "HMRC-PILLAR2-ORG"                    => "PLR"
     }
   }
 

--- a/it/test/uk/gov/hmrc/agentaccesscontrol/SaAuthorisationISpec.scala
+++ b/it/test/uk/gov/hmrc/agentaccesscontrol/SaAuthorisationISpec.scala
@@ -181,10 +181,9 @@ class SaAuthorisationISpec
           successfulResponsePrincipal(Seq(testProviderId, "78741987654329", "78741987654322"))
         )
         stubQueryUsersAssignedEnrolmentsDelegatedSa(testSaUtr)(OK, successfulResponseDelegated(Seq(testProviderId)))
-        stubDesSaAgentClientRelationship(testSaAgentReference, testSaUtr)(
-          OK,
-          successfulDesSaResponse(auth_64_8 = false, auth_i64_8 = false)
-        )
+        stubDesSaAgentClientRelationship(testSaAgentReference, testSaUtr)(NOT_FOUND)
+        stubDesSaAgentClientRelationship(SaAgentReference("SA6012"), testSaUtr)(NOT_FOUND)
+        stubDesSaAgentClientRelationship(SaAgentReference("A1709A"), testSaUtr)(NOT_FOUND)
 
         val result = get(url)
         result.status shouldBe UNAUTHORIZED
@@ -291,6 +290,14 @@ class SaAuthorisationISpec
         )
         stubQueryUsersAssignedEnrolmentsDelegatedSa(testSaUtr)(OK, successfulResponseDelegated(Seq(testProviderId)))
         stubDesSaAgentClientRelationship(testSaAgentReference, testSaUtr)(
+          OK,
+          successfulDesSaResponse(auth_64_8 = true, auth_i64_8 = true)
+        )
+        stubDesSaAgentClientRelationship(SaAgentReference("SA6012"), testSaUtr)(
+          OK,
+          successfulDesSaResponse(auth_64_8 = true, auth_i64_8 = true)
+        )
+        stubDesSaAgentClientRelationship(SaAgentReference("A1709A"), testSaUtr)(
           OK,
           successfulDesSaResponse(auth_64_8 = true, auth_i64_8 = true)
         )
@@ -471,10 +478,9 @@ class SaAuthorisationISpec
           successfulResponsePrincipal(Seq(testProviderId, "78741987654329", "78741987654322"))
         )
         stubQueryUsersAssignedEnrolmentsDelegatedSa(testSaUtr)(OK, successfulResponseDelegated(Seq(testProviderId)))
-        stubDesSaAgentClientRelationship(testSaAgentReference, testSaUtr)(
-          OK,
-          successfulDesSaResponse(auth_64_8 = false, auth_i64_8 = false)
-        )
+        stubDesSaAgentClientRelationship(testSaAgentReference, testSaUtr)(NOT_FOUND)
+        stubDesSaAgentClientRelationship(SaAgentReference("SA6012"), testSaUtr)(NOT_FOUND)
+        stubDesSaAgentClientRelationship(SaAgentReference("A1709A"), testSaUtr)(NOT_FOUND)
 
         val result = post(url)(Json.obj())
         result.status shouldBe UNAUTHORIZED
@@ -581,6 +587,14 @@ class SaAuthorisationISpec
         )
         stubQueryUsersAssignedEnrolmentsDelegatedSa(testSaUtr)(OK, successfulResponseDelegated(Seq(testProviderId)))
         stubDesSaAgentClientRelationship(testSaAgentReference, testSaUtr)(
+          OK,
+          successfulDesSaResponse(auth_64_8 = true, auth_i64_8 = true)
+        )
+        stubDesSaAgentClientRelationship(SaAgentReference("SA6012"), testSaUtr)(
+          OK,
+          successfulDesSaResponse(auth_64_8 = true, auth_i64_8 = true)
+        )
+        stubDesSaAgentClientRelationship(SaAgentReference("A1709A"), testSaUtr)(
           OK,
           successfulDesSaResponse(auth_64_8 = true, auth_i64_8 = true)
         )

--- a/it/test/uk/gov/hmrc/agentaccesscontrol/StandardServicesAuthorisationISpec.scala
+++ b/it/test/uk/gov/hmrc/agentaccesscontrol/StandardServicesAuthorisationISpec.scala
@@ -84,7 +84,7 @@ class StandardServicesAuthorisationISpec
             stubAgentNotSuspended
             stubAgentPermissionsOptInRecordExists(testArn)(OK)
             stubAgentClientRelationship(testArn, serviceConfig)(OK)
-            stubGetAgentPermissionTaxGroup(testArn, serviceConfig.taxGroup.service)(OK, serviceConfig.taxGroup)
+            stubGetAgentPermissionTaxGroup(testArn, serviceConfig.taxGroup.service)(serviceConfig.taxGroup)
 
             val result = {
               requestMethod match {
@@ -101,7 +101,7 @@ class StandardServicesAuthorisationISpec
             stubAgentNotSuspended
             stubAgentPermissionsOptInRecordExists(testArn)(NO_CONTENT)
             stubAgentClientRelationship(testArn, serviceConfig)(OK)
-            stubGetAgentPermissionTaxGroup(testArn, serviceConfig.taxGroup.service)(NOT_FOUND, serviceConfig.taxGroup)
+            stubGetAgentPermissionTaxGroupNotFound(testArn, serviceConfig.taxGroup.service)
             stubAgentClientRelationshipAssigned(testArn, serviceConfig, testProviderId)(OK)
 
             val result = {
@@ -118,7 +118,7 @@ class StandardServicesAuthorisationISpec
             stubAgentNotSuspended
             stubAgentPermissionsOptInRecordExists(testArn)(NO_CONTENT)
             stubAgentClientRelationship(testArn, serviceConfig)(OK)
-            stubGetAgentPermissionTaxGroup(testArn, serviceConfig.taxGroup.service)(NOT_FOUND, serviceConfig.taxGroup)
+            stubGetAgentPermissionTaxGroupNotFound(testArn, serviceConfig.taxGroup.service)
             stubAgentClientRelationshipAssigned(testArn, serviceConfig, testProviderId)(NOT_FOUND)
 
             val result = {
@@ -136,7 +136,7 @@ class StandardServicesAuthorisationISpec
             stubAgentNotSuspended
             stubAgentPermissionsOptInRecordExists(testArn)(NO_CONTENT)
             stubAgentClientRelationship(testArn, serviceConfig)(OK)
-            stubGetAgentPermissionTaxGroup(testArn, serviceConfig.taxGroup.service)(OK, serviceConfig.taxGroup)
+            stubGetAgentPermissionTaxGroup(testArn, serviceConfig.taxGroup.service)(serviceConfig.taxGroup)
 
             val result = {
               requestMethod match {

--- a/it/test/uk/gov/hmrc/agentaccesscontrol/stubs/AgentPermissionsStub.scala
+++ b/it/test/uk/gov/hmrc/agentaccesscontrol/stubs/AgentPermissionsStub.scala
@@ -17,6 +17,8 @@
 package uk.gov.hmrc.agentaccesscontrol.stubs
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.http.Status.NOT_FOUND
+import play.api.http.Status.OK
 import uk.gov.hmrc.agentaccesscontrol.models.accessgroups.TaxGroup
 import uk.gov.hmrc.agentaccesscontrol.models.Arn
 import uk.gov.hmrc.agentaccesscontrol.utils.WiremockMethods
@@ -29,10 +31,16 @@ trait AgentPermissionsStub extends WiremockMethods {
       uri = s"/agent-permissions/arn/${arn.value}/optin-record-exists"
     ).thenReturn(status)
 
-  def stubGetAgentPermissionTaxGroup(arn: Arn, taxService: String)(status: Int, taxGroup: TaxGroup): StubMapping =
+  def stubGetAgentPermissionTaxGroup(arn: Arn, taxService: String)(taxGroup: TaxGroup): StubMapping =
     when(
       method = GET,
       uri = s"/agent-permissions/arn/${arn.value}/tax-group/$taxService"
-    ).thenReturn(status, taxGroup)
+    ).thenReturn(OK, taxGroup)
+
+  def stubGetAgentPermissionTaxGroupNotFound(arn: Arn, taxService: String): StubMapping =
+    when(
+      method = GET,
+      uri = s"/agent-permissions/arn/${arn.value}/tax-group/$taxService"
+    ).thenReturn(NOT_FOUND)
 
 }

--- a/it/test/uk/gov/hmrc/agentaccesscontrol/stubs/DesStub.scala
+++ b/it/test/uk/gov/hmrc/agentaccesscontrol/stubs/DesStub.scala
@@ -39,7 +39,7 @@ trait DesStub extends WiremockMethods {
   def stubDesSaAgentClientRelationship(
       saAgentReference: SaAgentReference,
       saUtr: SaUtr
-  )(status: Int, body: JsValue): StubMapping =
+  )(status: Int, body: JsValue = Json.obj()): StubMapping =
     when(
       method = GET,
       uri = s"/sa/agents/${saAgentReference.value}/client/${saUtr.value}",


### PR DESCRIPTION
I deleted two tests in `GranularPermissionsAuthorisationISpec`. These tests were essentially the same scenarios as others in the spec, but were setting up stubbing that made no sense. The coverage report before and after deleting the tests confirms that no coverage was lost. Further details of the removed tests:
- “agent user is in a tax group for a different service” - this was stubbing an existing VAT tax group, but as the request into the service is for CGT, a request to check for a VAT tax group does not happen
- “agent user is in the tax group but there is no agency-level relationship” - this was stubbing various calls using an identifier testCgtRef, but passing another CGT ref into the request URI, meaning none of the relevant stubs with testCgtRef were being called